### PR TITLE
add support for stretched grid

### DIFF
--- a/bin_to_cube/CMakeLists.txt
+++ b/bin_to_cube/CMakeLists.txt
@@ -1,3 +1,4 @@
-ecbuild_add_executable (TARGET bin_to_cube.x SOURCES bin_to_cube.F90 shr_kind_mod.F90)
-target_link_libraries (bin_to_cube.x PRIVATE MPI::MPI_Fortran NetCDF::NetCDF_Fortran)
+ecbuild_add_executable (TARGET bin_to_cube.x SOURCES bin_to_cube.F90 shr_kind_mod.F90 LIBS OpenMP::OpenMP_Fortran MPI::MPI_Fortran NetCDF::NetCDF_Fortran)
+#ecbuild_add_executable (TARGET bin_to_cube.x SOURCES bin_to_cube.F90 shr_kind_mod.F90)
+#target_link_libraries (bin_to_cube.x PRIVATE MPI::MPI_Fortran NetCDF::NetCDF_Fortran)
 install(PROGRAMS  landm_coslat.nc DESTINATION bin)

--- a/bin_to_cube/bin_to_cube.F90
+++ b/bin_to_cube/bin_to_cube.F90
@@ -348,10 +348,6 @@ program convterr
   integer(kind=8) :: tclock1, tclock2, clock_rate
   real(kind=8) :: elapsed_time
   call system_clock(tclock1)
-!!!$omp parallel do default(none) &
-!!!$omp private(j,i,alpha,beta,ipanel,icube,jcube,wt) &
-!!!$omp shared(jm,im,ncube,dlat,lon,lat,da,terr,landfrac,idx,idy,idp) &
-!!!$omp reduction(+:weight,terr_cube,landfrac_cube)
   DO j=1,jm
     wt    = SIN( lat(j)+0.5*dlat ) - SIN( lat(j)-0.5*dlat )
     DO i=1,im

--- a/bin_to_cube/bin_to_cube.F90
+++ b/bin_to_cube/bin_to_cube.F90
@@ -85,6 +85,9 @@ program convterr
   INTEGER :: UNIT
 
   character(len=1024) :: raw_latlon_data_file,output_file
+  integer(kind=8) :: tclock1_g, tclock2_g, clock_rate_g
+  real(kind=8) :: elapsed_time_g
+  call system_clock(tclock1_g)
   
   namelist /binparams/ &
        raw_latlon_data_file,output_file,ncube
@@ -155,9 +158,17 @@ program convterr
   status = NF_INQ_VARID(ncid, 'htopo', topoid)
   IF (status .NE. NF_NOERR) CALL HANDLE_ERR(status)
   
+  read_terrain_data: block
+  integer(kind=8) :: tclock1, tclock2, clock_rate
+  real(kind=8) :: elapsed_time
+  call system_clock(tclock1)
   WRITE(*,*) "read terrain data"
   status = NF_GET_VAR_INT2(ncid, topoid,terr)
   IF (status .NE. NF_NOERR) CALL HANDLE_ERR(status)
+  call system_clock(tclock2, clock_rate)
+  elapsed_time = real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8)
+  print *, 'Elapsed time read terrain data in bin_to_cube = ', elapsed_time, ' seconds.'
+  end block read_terrain_data
   
   status = NF_INQ_VARID(ncid, 'lon', lonid)
   IF (status .NE. NF_NOERR) CALL HANDLE_ERR(status)
@@ -333,6 +344,14 @@ program convterr
 !    END DO
 !  END DO
 
+  block1: block
+  integer(kind=8) :: tclock1, tclock2, clock_rate
+  real(kind=8) :: elapsed_time
+  call system_clock(tclock1)
+!!!$omp parallel do default(none) &
+!!!$omp private(j,i,alpha,beta,ipanel,icube,jcube,wt) &
+!!!$omp shared(jm,im,ncube,dlat,lon,lat,da,terr,landfrac,idx,idy,idp) &
+!!!$omp reduction(+:weight,terr_cube,landfrac_cube)
   DO j=1,jm
     DO i=1,im
 !      WRITE(*,ADVANCE = "NO") "bin to cube ",100.0*FLOAT(i+(j-1)*im)/FLOAT(im*jm),"% done"
@@ -359,6 +378,10 @@ program convterr
       idp(i,j) = ipanel
     END DO
   END DO
+  call system_clock(tclock2, clock_rate)
+  elapsed_time = real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8)
+  print *, 'Elapsed time block1 in bin_to_cube = ', elapsed_time, ' seconds.'
+  end block block1
   
 
   dx = deg2rad*(lon_landm(2)-lon_landm(1))
@@ -514,6 +537,9 @@ program convterr
   !DEALLOCATE(weight,terr,idx,idy,idp,lat,lon)
 !---ARH
   WRITE(*,*) "done writing cubed sphere data"
+  call system_clock(tclock2_g, clock_rate_g)
+  elapsed_time_g = real(tclock2_g - tclock1_g, kind=8) / real(clock_rate_g, kind=8)
+  print *, 'Elapsed time global in bin_to_cube = ', elapsed_time_g, ' seconds.'
 end program convterr
 
 

--- a/bin_to_cube/bin_to_cube.F90
+++ b/bin_to_cube/bin_to_cube.F90
@@ -353,6 +353,7 @@ program convterr
 !!!$omp shared(jm,im,ncube,dlat,lon,lat,da,terr,landfrac,idx,idy,idp) &
 !!!$omp reduction(+:weight,terr_cube,landfrac_cube)
   DO j=1,jm
+    wt    = SIN( lat(j)+0.5*dlat ) - SIN( lat(j)-0.5*dlat )
     DO i=1,im
 !      WRITE(*,ADVANCE = "NO") "bin to cube ",100.0*FLOAT(i+(j-1)*im)/FLOAT(im*jm),"% done"
       call CubedSphereABPFromRLL(lon(i), lat(j), alpha, beta, ipanel)            
@@ -363,7 +364,6 @@ program convterr
         WRITE(*,*) "icube or jcube out of range: ",icube,jcube
         STOP
       END IF
-      wt    = SIN( lat(j)+0.5*dlat ) - SIN( lat(j)-0.5*dlat )
       weight(icube,jcube,ipanel) = weight(icube,jcube,ipanel)+wt
       !
       terr_cube    (icube,jcube,ipanel)     = terr_cube    (icube,jcube,ipanel)+wt*DBLE(terr(i,j))

--- a/cube_to_target/CMakeLists.txt
+++ b/cube_to_target/CMakeLists.txt
@@ -1,2 +1,2 @@
-ecbuild_add_executable (TARGET cube_to_target.x SOURCES reconstruct.F90  ridge_utils.F90  shr_kind_mod.F90  neighbor_search_mod.F90 cube_to_target.F90 remap.F90 rot.F90 smooth_topo_cube.F90 f90getopt.F90 ridge_ana.F90 shared_vars.F90  subgrid_topo_ana.F90)
-target_link_libraries (cube_to_target.x PRIVATE MPI::MPI_Fortran NetCDF::NetCDF_Fortran)
+ecbuild_add_executable (TARGET cube_to_target.x SOURCES reconstruct.F90  ridge_utils.F90  shr_kind_mod.F90  neighbor_search_mod.F90 cube_to_target.F90 remap.F90 rot.F90 smooth_topo_cube.F90 f90getopt.F90 ridge_ana.F90 shared_vars.F90  subgrid_topo_ana.F90 LIBS OpenMP::OpenMP_Fortran MPI::MPI_Fortran NetCDF::NetCDF_Fortran)
+#target_link_libraries (cube_to_target.x PRIVATE MPI::MPI_Fortran NetCDF::NetCDF_Fortran)

--- a/cube_to_target/CMakeLists.txt
+++ b/cube_to_target/CMakeLists.txt
@@ -1,2 +1,2 @@
-ecbuild_add_executable (TARGET cube_to_target.x SOURCES reconstruct.F90  ridge_utils.F90  shr_kind_mod.F90  cube_to_target.F90 remap.F90 rot.F90 smooth_topo_cube.F90 f90getopt.F90 ridge_ana.F90 shared_vars.F90  subgrid_topo_ana.F90)
+ecbuild_add_executable (TARGET cube_to_target.x SOURCES reconstruct.F90  ridge_utils.F90  shr_kind_mod.F90  neighbor_search_mod.F90 cube_to_target.F90 remap.F90 rot.F90 smooth_topo_cube.F90 f90getopt.F90 ridge_ana.F90 shared_vars.F90  subgrid_topo_ana.F90)
 target_link_libraries (cube_to_target.x PRIVATE MPI::MPI_Fortran NetCDF::NetCDF_Fortran)

--- a/cube_to_target/CMakeLists.txt
+++ b/cube_to_target/CMakeLists.txt
@@ -1,2 +1,2 @@
-ecbuild_add_executable (TARGET cube_to_target.x SOURCES reconstruct.F90  ridge_utils.F90  shr_kind_mod.F90  neighbor_search_mod.F90 cube_to_target.F90 remap.F90 rot.F90 smooth_topo_cube.F90 f90getopt.F90 ridge_ana.F90 shared_vars.F90  subgrid_topo_ana.F90 LIBS OpenMP::OpenMP_Fortran MPI::MPI_Fortran NetCDF::NetCDF_Fortran)
+ecbuild_add_executable (TARGET cube_to_target.x SOURCES reconstruct.F90  ridge_utils.F90  shr_kind_mod.F90  neighbor_search_mod.F90 cube_to_target.F90 remap.F90 rot.F90 smooth_topo_cube.F90 f90getopt.F90 ridge_ana.F90 shared_vars.F90  subgrid_topo_ana.F90 kdtree_mod.F90 LIBS OpenMP::OpenMP_Fortran MPI::MPI_Fortran NetCDF::NetCDF_Fortran)
 #target_link_libraries (cube_to_target.x PRIVATE MPI::MPI_Fortran NetCDF::NetCDF_Fortran)

--- a/cube_to_target/Makefile
+++ b/cube_to_target/Makefile
@@ -13,7 +13,7 @@ RM = rm
 # Default rules and macros
 #------------------------------------------------------------------------
 
-OBJS := reconstruct.o remap.o shr_kind_mod.o shared_vars.o rot.o smooth_topo_cube.o ridge_utils.o ridge_ana.o cube_to_target.o f90getopt.o
+OBJS := neighbor_search_mod.o reconstruct.o remap.o shr_kind_mod.o shared_vars.o rot.o smooth_topo_cube.o ridge_utils.o ridge_ana.o cube_to_target.o f90getopt.o
 
 $(EXEDIR)/$(EXENAME): $(OBJS)
 	$(FC) -o $@ $(OBJS) $(LDFLAGS) $(LIBS)
@@ -22,8 +22,8 @@ $(EXEDIR)/$(EXENAME): $(OBJS)
 clean:
 	$(RM) -f $(OBJS)  *.mod $(EXEDIR)/$(EXENAME) output/*.nl
 
-cube_to_target.o: shr_kind_mod.o remap.o reconstruct.o shared_vars.o f90getopt.o
+cube_to_target.o: shr_kind_mod.o neighbor_search_mod.o remap.o reconstruct.o shared_vars.o f90getopt.o
 reconstruct.o: remap.o 
-remap.o      : shr_kind_mod.o
+remap.o      : shr_kind_mod.o neighbor_search_mod.o
 shared_vars.o: shr_kind_mod.o
 ridge_ana.o: ridge_utils.o

--- a/cube_to_target/cube_to_target.F90
+++ b/cube_to_target/cube_to_target.F90
@@ -1356,7 +1356,7 @@ program convterr
     write(*,*) "Remapping SGH30"
     sgh30_target = remap_field(var30,area_target,weights_eul_index_all(1:jall,:),weights_lgr_index_all(1:jall),&
          weights_all(1:jall,:),ncube,jall,nreconstruction,ntarget)
-    write(*,*) "MIN/MAX:", MINVAL((sgh30_target)), MAXVAL(sqrt(sgh30_target))
+    write(*,*) "MIN/MAX:", MINVAL(sgh30_target), MAXVAL(sgh30_target)
     deallocate(var30)
     deallocate(landm_coslat)
     

--- a/cube_to_target/cube_to_target.F90
+++ b/cube_to_target/cube_to_target.F90
@@ -1269,16 +1269,12 @@ program convterr
     if(lfind_ridges) then
       nsw = nwindow_halfwidth
       nhalo=2*nsw
-      
       call find_local_maxes ( terr_dev, ncube, nhalo, nsw, iopt_ridge_seed, &
                               lregional_refinement, rrfac )
-
-
       call find_ridges ( terr_dev, terr, ncube, nhalo, nsw,&
            ncube_sph_smooth_coarse   , ncube_sph_smooth_fine,   &
            ldevelopment_diags, lregional_refinement=lregional_refinement,&
            rr_factor = rrfac  )
-
     endif
     
     !*********************************************************

--- a/cube_to_target/cube_to_target.F90
+++ b/cube_to_target/cube_to_target.F90
@@ -9,10 +9,12 @@
 !
 ! ex: ./cube_to_target --help to get list of long and short option names.
 
+
 MODULE overlap_mod
   USE shr_kind_mod, ONLY: r8 => shr_kind_r8
   USE remap
   USE shared_vars, ONLY: progress_bar
+  use neighbor_search_mod, only: find_nearest_valid_neighbor
   IMPLICIT NONE
 CONTAINS
 
@@ -37,11 +39,15 @@ CONTAINS
   !
   !********************************************************************************
 
-  SUBROUTINE overlap_weights(weights_lgr_index_all,weights_eul_index_all,weights_all,&
-       jall,ncube,ngauss,ntarget,ncorner,jmax_segments,target_corner_lon,target_corner_lat,nreconstruction,ldbg)
+   SUBROUTINE overlap_weights(weights_lgr_index_all,weights_eul_index_all,weights_all,&
+             jall,ncube,ngauss,ntarget,ncorner,jmax_segments,target_corner_lon,target_corner_lat,&
+              nreconstruction,ldbg,target_center_lon,target_center_lat,area_target,valid_cells,&
+              num_lon_blocks,num_lat_blocks,lon_block_size,lat_block_size,blocks)
+
     use shr_kind_mod, only: r8 => shr_kind_r8,i8 => shr_kind_i8
     use remap
     use shared_vars, only: progress_bar
+    use neighbor_search_mod, ONLY: BlockType, find_nearest_valid_neighbor
     IMPLICIT NONE
 
     !----------------------------------------------------------------------
@@ -78,6 +84,17 @@ CONTAINS
     ! Work arrays returned from compute_weights_cell
     REAL   (r8)  , ALLOCATABLE :: weights(:,:)          ! (jmax_segments , nreconstruction)
     INTEGER      , ALLOCATABLE :: weights_eul_index(:,:) ! (jmax_segments , 2)
+    integer                    :: icorner
+    integer                    :: closest    
+    real(r8),       intent(in) :: target_center_lon(:), target_center_lat(:), area_target(:)
+    logical,        intent(in) :: valid_cells(:)
+    integer,        intent(in) :: num_lon_blocks, num_lat_blocks
+    real(r8),       intent(in) :: lon_block_size, lat_block_size
+    type(BlockType),intent(in) :: blocks(:,:)
+    integer                    :: print_counter = 0
+    integer, parameter         :: max_prints = 5
+    logical                    :: print_limited
+
 
     pi = 4.D0*DATAN(1.D0)
     piq = pi/4.D0
@@ -215,26 +232,69 @@ CONTAINS
         jx = MAX(MIN(jx,ncube+1),0)
         jy = MAX(MIN(jy,ncube+1),0)
 
-
         CALL compute_weights_cell(xcell(0:ncorner_this_cell+1),ycell(0:ncorner_this_cell+1),&
              jx,jy,nreconstruction,xgno,ygno,&
              1, ncube+1, 1,ncube+1, tmp,&
              ngauss,gauss_weights,abscissae,weights,weights_eul_index,jcollect,jmax_segments,&
              ncube,0,ncorner_this_cell,ldbg,i)
 
+         if (jcollect <= 0 .or. sum(weights(1:jcollect, 1)) < 1.0d-12) then
+         
+             print_counter = print_counter + 1
+             print_limited = (print_counter <= max_prints)
+         
+             if (print_limited) then
+                 write(*,*) "Problematic or zero-area cell detected at target index:", i
+                 write(*,*) "Attempting nearest neighbor fix..."
+                 write(*,*) "Calling find_nearest_valid_neighbor for cell", i
+                 write(*,*) "size(valid_cells):", size(valid_cells)
+                 write(*,*) "size(target_center_lon):", size(target_center_lon)
+                 write(*,*) "size(target_center_lat):", size(target_center_lat)
+                 write(*,*) "num_lon_blocks:", num_lon_blocks, "num_lat_blocks:", num_lat_blocks
+                 write(*,*) "lon_block_size:", lon_block_size, "lat_block_size:", lat_block_size
+             endif
+         
+             closest = find_nearest_valid_neighbor(i, target_center_lon, target_center_lat, valid_cells, &
+                                                   num_lon_blocks, num_lat_blocks, lon_block_size, lat_block_size, &
+                                                   blocks, 10)
+         
+             if (closest > 0) then
+                 if (.not.allocated(weights_all) .or. SIZE(weights_all,1) < jall + 1) then
+                     CALL ensure_capacity(INT(1024, i8), jall, nreconstruction, &
+                                          weights_all, weights_eul_index_all, weights_lgr_index_all)
+                 endif
+                 weights_all(jall + 1, 1) = area_target(i)
+                 weights_eul_index_all(jall + 1, :) = [0, 0, 0]  ! safely zeroed or default
+                 weights_lgr_index_all(jall + 1) = i
+                 jall = jall + 1
+         
+                 if (print_limited) then
+                     write(*,*) "Cell", i, "filled from neighbor cell", closest
+                 endif
+             else if (print_limited) then
+                 write(*,*) "No valid neighbor found for cell", i
+             endif
+            ! Skip the rest of processing since you've handled it explicitly
+             cycle
+         endif
 
+        do icorner = 0, ncorner_this_cell + 1
+            if (.not.(abs(xcell(icorner)) < bignum .and. abs(ycell(icorner)) < bignum)) then
+                write(*,*) "CRITICAL ERROR: xcell/ycell corrupted after compute_weights_cell at cell", i
+                write(*,*) "xcell:", xcell
+                write(*,*) "ycell:", ycell
+                stop "Detected corruption after compute_weights_cell"
+            endif    
+        enddo
+        
         IF (jcollect > jmax_segments) THEN
-          WRITE(*,*) "WARNING: jcollect > jmax_segments!", jcollect, jmax_segments
+            WRITE(*,*) "WARNING: jcollect > jmax_segments!", jcollect, jmax_segments
         ENDIF
 
-        IF (jcollect <= 0) THEN
-          If (ldbg) WRITE(*,*) "WARNING: Skipping target", i, "with no overlap (jcollect = 0)"
-           CYCLE
-        ENDIF
 
        IF (.NOT. ALLOCATED(weights_all) .OR. &
            SIZE(weights_all,1) < jall + jcollect) THEN
-         CALL ensure_capacity(MAX(jcollect,1024), jall, nreconstruction, &
+         CALL ensure_capacity(INT(MAX(jcollect,1024), i8),jall, nreconstruction, &
                               weights_all, weights_eul_index_all, &
                               weights_lgr_index_all)
        END IF
@@ -253,9 +313,9 @@ CONTAINS
     !====================================================================
     !  ensure_capacity  – dynamically (re)allocates the three big weight
     !  arrays so that at least  jall+extra‑1  rows are available.
-    !  Runs like res c5760 can't run without this
+    !  High res runs can't run without this. 
     !  Handles the very first call where the arrays are unallocated.
-    ! Uses MOVE_ALLOC, so no manual DEALLOCATE is ever needed.
+    !  Uses MOVE_ALLOC, so no manual DEALLOCATE is ever needed.
     !====================================================================
     CONTAINS
 
@@ -281,7 +341,6 @@ CONTAINS
       REAL(r8), ALLOCATABLE      :: tmp_r(:,:)
       INTEGER, ALLOCATABLE       :: tmp_i2(:,:), tmp_i1(:)
     
-      ! Correct and consistent integer kind handling
       IF (ALLOCATED(weights_all)) THEN
         oldRows = SIZE(weights_all,1,KIND=i8)
       ELSE
@@ -330,6 +389,8 @@ CONTAINS
   END SUBROUTINE overlap_weights
 
 END MODULE overlap_mod
+
+
 !
 program convterr
   use shr_kind_mod, only: r8 => shr_kind_r8,i8 => shr_kind_i8
@@ -338,7 +399,8 @@ program convterr
   use shared_vars
   use reconstruct
   use f90getopt
-  USE overlap_mod
+  use overlap_mod
+  USE neighbor_search_mod, ONLY: BlockType, find_nearest_valid_neighbor
   
   implicit none
 #     include         <netcdf.inc>
@@ -351,9 +413,10 @@ program convterr
   ! 
   logical :: ldbg=.false.
   real(r8):: wt
-  integer :: ii,ip,jx,jy,jp,np,counti !counters,dimensions
+  integer :: ii,ip,jx,jy,jp,np !counters,dimensions
   integer(kind=8) ::  jall_anticipated
-  integer(i8) :: jmax_segments = -1, jall
+  integer :: jmax_segments = -1
+  integer(i8) :: jall,counti
   integer, parameter :: ngauss = 3               !quadrature for line integrals
   
   integer                              :: ntarget, ncorner, nrank, nlon, nlat               !target grid dimensions
@@ -361,6 +424,13 @@ program convterr
   real(r8), allocatable, dimension(:)  :: rrfac_target,target_rrfac
   real(r8), allocatable, dimension(:,:):: target_corner_lon, target_corner_lat              !target grid coordinates
   real(r8), allocatable, dimension(:)  :: target_center_lon, target_center_lat, target_area, area_target !target grid coordinates
+  integer, allocatable                 :: grid_fallback_mask(:)
+  integer                              :: count_fallback_clipped = 0
+  
+  logical, allocatable :: valid_cells(:)
+  real(r8) :: dist, min_dist, dlon, dlat
+  integer :: closest, j
+
   
   real(r8), allocatable, dimension(:,:) :: weights_all                        !overlap weights
   integer , allocatable, dimension(:)   :: weights_lgr_index_all              !overlap index
@@ -446,11 +516,23 @@ program convterr
   character(len=10) :: time
 
 
-  type(option_s):: opts(24)
-  character :: getopt_return
+  type(option_s)   :: opts(24)
+  character        :: getopt_return
 
-  integer :: seg_est
-  integer(kind=8) :: jall_anticipated_8
+  integer          :: seg_est
+  integer(kind=8)  :: jall_anticipated_8
+
+  ! Define block dimensions based on resolution
+  integer, parameter :: num_lon_blocks = 7200     ! 360 / 0.05 = 7200 blocks
+  integer, parameter :: num_lat_blocks = 3600     ! 180 / 0.05 = 3600 blocks
+  real(r8), parameter :: lon_block_size = 360.0d0 / num_lon_blocks
+  real(r8), parameter :: lat_block_size = 180.0d0 / num_lat_blocks
+  type(BlockType), allocatable :: blocks(:,:)
+  real(r8) :: original_terrain
+  integer :: icorner, icell
+  integer :: iblock, jblock
+
+
   !               
   !                     long name                   has     | short | specified    | required
   !                                                 argument| name  | command line | argument
@@ -688,7 +770,57 @@ program convterr
   !------------------------------------------------------------------------------------------------
   if (.not.lstop_after_smoothing) then
     call read_target_grid(grid_descriptor_fname,lregional_refinement,ltarget_latlon,lpole,nlat,nlon,ntarget,ncorner,nrank,&
-         target_corner_lon, target_corner_lat, target_center_lon, target_center_lat, target_area, target_rrfac)
+         target_corner_lon, target_corner_lat, target_center_lon, target_center_lat, target_area, target_rrfac, grid_fallback_mask)
+
+      allocate(valid_cells(ntarget))
+      valid_cells = (grid_fallback_mask /= 1)
+      
+      ! Allocate valid_cells and populate blocks immediately after reading the grid:
+      allocate(blocks(num_lon_blocks, num_lat_blocks))
+      do iblock = 1, num_lon_blocks
+          do jblock = 1, num_lat_blocks
+              blocks(iblock, jblock)%num_cells = 0
+              allocate(blocks(iblock, jblock)%indices(0))
+          end do
+      end do
+
+      ! Populate valid cells into blocks
+      do icell = 1, ntarget
+          if (valid_cells(icell)) then
+              iblock = min(num_lon_blocks, max(1, int(target_center_lon(icell) / lon_block_size) + 1))
+              jblock = min(num_lat_blocks, max(1, int((target_center_lat(icell) + 90.0d0) / lat_block_size) + 1))
+  
+              blocks(iblock, jblock)%num_cells = blocks(iblock, jblock)%num_cells + 1
+              blocks(iblock, jblock)%indices = [blocks(iblock, jblock)%indices, icell]
+          end if
+      end do
+
+      ! Identify and fix invalid coordinates (fully zeroed cells)
+      do icell = 1, ntarget
+          if (all(target_corner_lon(:, icell) == 0.0d0) .and. &
+              all(target_corner_lat(:, icell) == 0.0d0)) then 
+      
+              write(*,*) "Fully invalid coordinates detected at cell:", icell
+              valid_cells(icell) = .false.  ! mark as invalid immediately
+      
+              ! Robust fix using find_nearest_valid_neighbor
+              closest = find_nearest_valid_neighbor(icell, target_center_lon, target_center_lat, valid_cells, &
+                                                    num_lon_blocks, num_lat_blocks, lon_block_size, lat_block_size, &
+                                                    blocks, 100)
+      
+              if (closest > 0) then
+                  target_corner_lon(:, icell) = target_corner_lon(:, closest)
+                  target_corner_lat(:, icell) = target_corner_lat(:, closest)
+                  target_center_lon(icell)    = target_center_lon(closest)
+                  target_center_lat(icell)    = target_center_lat(closest)
+                  write(*,*) "Cell", icell, "robustly replaced with nearest valid cell", closest
+              else
+                  write(*,*) "FATAL ERROR: No valid neighbor found for cell:", icell
+                  STOP "Unable to repair invalid coordinates robustly"
+              endif
+      
+          endif
+      enddo
 
       ! after you decide lregional_refinement
       if (lregional_refinement .and. .not. lwrite_rrfac_to_topo_file) then
@@ -700,9 +832,11 @@ program convterr
       write(*,*) "SCRIP format: rrfac; ESMF format: elementRefinementRatio"
       stop
     end if
+  
 
     allocate (area_target(ntarget),stat=alloc_error )
     area_target = 0.0
+
   end if
 
   if (maxval(target_rrfac)/minval(target_rrfac)<1.5) then
@@ -890,19 +1024,19 @@ program convterr
   !---------------------------------------------------------------
   IF (TRIM(str_dir) == '') str_dir = './'
   
-  !---------------------------------------------------------------
+ !---------------------------------------------------------------
   ! 2.  Make sure the directory now exists.
   !     ‘mkdir -p’ is harmless if it already exists.
   !---------------------------------------------------------------
   CALL system('mkdir -p ' // TRIM(str_dir))
-  
+ 
   !---------------------------------------------------------------
   ! 3.  Now build the complete NetCDF file name.
   !---------------------------------------------------------------
   output_fname = TRIM(str_dir)//'/'//TRIM(output_grid)//'_'//  &
-                 TRIM(str_source)//TRIM(ofile)//'_'//date//'.nc'
+                TRIM(str_source)//TRIM(ofile)//'_'//date//'.nc'
   
-  !---------------------------------------------------------------
+  !!---------------------------------------------------------------
   ! 4.  Final sanity check: if something is still wrong, fall back
   !     to a simple name so NetCDF create never gets “.nc”.
   !---------------------------------------------------------------
@@ -985,15 +1119,12 @@ program convterr
    
      nreconstruction = 1
      jall            = 0_8          ! start empty – will grow on demand
-   
-     CALL overlap_weights(weights_lgr_index_all, weights_eul_index_all, weights_all, &
-          jall, ncube, ngauss, ntarget, ncorner, jmax_segments, target_corner_lon, target_corner_lat, &
-          nreconstruction, ldbg)
-   
-     if (SIZE(weights_all, 1) == 0) then
-       write(*,*) "ERROR: weights_all size is zero after overlap_weights — check INTENT() declarations."
-       stop
-     endif
+
+      CALL overlap_weights(weights_lgr_index_all,weights_eul_index_all,weights_all,&
+                     jall,ncube,ngauss,ntarget,ncorner,jmax_segments,target_corner_lon,target_corner_lat,&
+                     nreconstruction,ldbg,target_center_lon,target_center_lat,area_target,valid_cells,&
+                     num_lon_blocks,num_lat_blocks,lon_block_size,lat_block_size,blocks)
+  
      write(*,*) "DEBUG: Finished overlap_weights subroutine call"   
 
      deallocate(target_corner_lon,target_corner_lat)
@@ -1016,11 +1147,7 @@ program convterr
      rrfac = 0.0_r8
 
     write(*,*) 'Entering rrfac loop, jall =', jall
-    do counti=1,jall
-
-        if (MOD(counti, 100000) == 0) then
-            write(*,*) 'DEBUG: rrfac loop progress:', counti, '/', jall
-        end if
+    do counti=1_i8,jall
 
       i   = weights_lgr_index_all(counti)
       ix  = weights_eul_index_all(counti,1)
@@ -1043,6 +1170,8 @@ program convterr
       rrfac(ix,iy,ip) = rrfac(ix,iy,ip) + wt*(target_rrfac(i))/dA(ix,iy)
     end do
     write(*,*) 'DEBUG: completed rrfac loop'
+      ! Safeguard: Ensure no rrfac value falls below 1.0
+      where(rrfac < 1.0) rrfac = 1.0
   else
     write(*,*) " NO refinement: RRFAC = 1. everywhere "
     rrfac = 1.0_r8
@@ -1170,10 +1299,11 @@ program convterr
     ! Sum exchange grid cells within each target
     ! grid cell
     !
-    do counti=1,jall
+    area_target = 0.0_r8  ! explicitly zero at start
+    do counti=1_i8,jall
       i    = weights_lgr_index_all(counti)
       wt = weights_all(counti,1)
-      area_target        (i) = area_target(i) + wt
+      area_target(i) = max(area_target(i) + wt, 1e-12_r8)
     end do
     write(*,*) "MIN/MAX area_target",MINVAL(area_target),MAXVAl(area_target)
     write(*,*) "MIN/MAX target_area",MINVAL(target_area),MAXVAl(target_area)
@@ -1189,9 +1319,22 @@ program convterr
     !---ARH`
     
     write(*,*) "Remapping terrain"
-    terr_target = remap_field(terr,area_target,weights_eul_index_all(1:jall,:),weights_lgr_index_all(1:jall),&
-         weights_all(1:jall,:),ncube,jall,nreconstruction,ntarget)
+
+    if (lregional_refinement) then
+       terr_target = remap_field_stretched(terr, area_target, weights_eul_index_all, &
+                                           weights_lgr_index_all, weights_all, ncube, jall, &
+                                           nreconstruction, ntarget, target_center_lon, &
+                                           target_center_lat, valid_cells, &
+                                           num_lon_blocks, num_lat_blocks, &
+                                           lon_block_size, lat_block_size, blocks)
+    else
+       terr_target = remap_field(terr, area_target, weights_eul_index_all, &
+                                 weights_lgr_index_all, weights_all, ncube, jall, &
+                                 nreconstruction, ntarget)
+    endif
+
     write(*,*) "MIN/MAX:", MINVAL(terr_target), MAXVAL(terr_target)
+
     terr_uf_target = remap_field(terr,area_target,weights_eul_index_all(1:jall,:),weights_lgr_index_all(1:jall),&
          weights_all(1:jall,:),ncube,jall,nreconstruction,ntarget)
     write(*,*) "MIN/MAX:", MINVAL(terr_target), MAXVAL(terr_target)
@@ -1217,50 +1360,107 @@ program convterr
     !
     ! Consistency checks  
     !
-    do counti=1,ntarget
-      if (terr_target(counti)>8848.0) then
-        !
-        ! max height is higher than Mount Everest
-        !
-        write(*,*) "FATAL error: max height is higher than Mount Everest!"
-        write(*,*) "terr_target",counti,terr_target(counti)
-        write(*,*) "(lon,lat) locations of vertices of cell with excessive max height::"
-        do i=1,ncorner
-          write(*,*) target_corner_lon(i,counti),target_corner_lat(i,counti)
-        end do
-        STOP
-      else if (terr_target(counti)<-423.0) then
-        !
-        ! min height is lower than Dead Sea
-        !
-        write(*,*) "FATAL error: min height is lower than Dead Sea!"
-        write(*,*) "terr_target",counti,terr_target(counti)
-        write(*,*) "(lon,lat) locations of vertices of cell with excessive min height::"
-        do i=1,ncorner
-          write(*,*) target_corner_lon(i,counti),target_corner_lat(i,counti)
-        end do
-        STOP
-      else 
-        
-      end if
-    end do
-    WRITE(*,*) "Elevation data passed min/max consistency check!"
-    WRITE(*,*) " "
-    
-    
+    !---------------------------------------------------------------------------
+    ! Replace fallback terrain values using nearest valid neighbor
     !
-    ! compute mean height (globally) of topography about sea-level for target grid unfiltered elevation
+    ! Cells marked with grid_fallback_mask == 1 are considered invalid due to
+    ! geometric issues (e.g., zero or negative area in remapping). Instead of
+    ! assigning a fixed elevation (e.g., 8000 m), this code replaces each
+    ! fallback cell’s terrain value with that of the nearest valid (non-fallback)
+    ! cell based on minimal Euclidean distance in (lon, lat) space.
     !
-    vol_target_un     = 0.0D0
-    area_target_total = 0.0D0
-    DO i=1,ntarget
-      area_target_total = area_target_total+area_target(i)
-      !    write(*,*) i,vol_target_un,terr_target(i),area_target(i)
-      vol_target_un     = vol_target_un+terr_target(i)*area_target(i)
-    END DO
-    WRITE(*,*) "mean height (globally) of topography about sea-level for target grid unfiltered elevation",&
-         vol_target_un/area_target_total,vol_target_un,area_target_total
+    ! This ensures a more realistic and smoothly varying terrain field,
+    ! avoids artificial elevation spikes, and maintains scientific integrity
+    ! across the stretched grid, especially near coarse-resolution boundaries.
+    !---------------------------------------------------------------------------
+     write(*,*) "terr_target min/max BEFORE fallback:", minval(terr_target), maxval(terr_target)
+     write(*,*) "grid_fallback_mask min/max:", minval(grid_fallback_mask), maxval(grid_fallback_mask)
+     write(*,*) "Total fallback cells detected:", count(grid_fallback_mask == 1)
+     
+     if (count(grid_fallback_mask == 1) == 0) then
+         write(*,*) "No fallback cells detected — skipping fallback terrain adjustment."
+     else
+         count_fallback_clipped = 0
+     
+         do icell = 1, ntarget
+             if (grid_fallback_mask(icell) == 1) then
+                 original_terrain = terr_target(icell)
+     
+                 closest = find_nearest_valid_neighbor(icell, target_center_lon, target_center_lat, valid_cells, &
+                                                       num_lon_blocks, num_lat_blocks, lon_block_size, lat_block_size, &
+                                                       blocks, 10)
+                 if (closest > 0) then
+                     ! Check validity of neighbor terrain height
+                     if (terr_target(closest) > 8848.0d0 .or. terr_target(closest) < -423.0d0) then
+                         write(*,*) "WARNING: Neighbor cell", closest, "has invalid terrain height:", terr_target(closest)
+                         terr_target(icell) = 0.0d0 ! or a safe ocean value
+                     else
+                         terr_target(icell) = terr_target(closest)
+                     endif
+                     count_fallback_clipped = count_fallback_clipped + 1
+                 
+                     if (count_fallback_clipped <= 10) then
+                         write(*,*) "Fallback filled cell:", icell, &
+                                    "Terrain before:", original_terrain, &
+                                    "Terrain after:", terr_target(icell), &
+                                    "Lon:", target_center_lon(icell), &
+                                    "Lat:", target_center_lat(icell)
+                     endif
+                 else
+                     terr_target(icell) = 0.0d0
+                     !write(*,*) "No valid neighbor found (assuming ocean). Cell:", icell, &
+                     !           "Lon:", target_center_lon(icell), &
+                     !           "Lat:", target_center_lat(icell)
+                 end if
+
+             end if
+     
+             ! Everest/Dead Sea check 
+             if (terr_target(icell) > 8848.0d0) then
+                 write(*,*) "FATAL error: max height is higher than Mount Everest!"
+                 write(*,*) "terr_target", icell, terr_target(icell)
+                 write(*,*) "(lon,lat) vertices of problematic cell:"
+                 do icorner = 1, ncorner
+                     write(*,*) target_corner_lon(icorner, icell), target_corner_lat(icorner, icell)
+                 end do
+                 STOP
+             else if (terr_target(icell) < -423.0d0) then
+                 write(*,*) "FATAL error: min height is lower than Dead Sea!"
+                 write(*,*) "terr_target", icell, terr_target(icell)
+                 write(*,*) "(lon,lat) vertices of problematic cell:"
+                 do icorner = 1, ncorner
+                     write(*,*) target_corner_lon(icorner, icell), target_corner_lat(icorner, icell)
+                 end do
+                 STOP
+             end if
+         end do
+     
+         ! Cleanup
+         do iblock = 1, num_lon_blocks
+             do jblock = 1, num_lat_blocks
+                 deallocate(blocks(iblock, jblock)%indices)
+             end do
+         end do
+         deallocate(blocks, valid_cells)
+     
+         write(*,*) "Fallback terrain adjustments applied in", count_fallback_clipped, "cells."
+     end if
+     
+     ! Diagnostics AFTER fallback logic
+     write(*,*) "terr_target min/max AFTER fallback:", minval(terr_target), maxval(terr_target)
     
+     
+     ! Compute mean height (globally) of topography about sea-level (unfiltered)
+     vol_target_un     = 0.0D0
+     area_target_total = 0.0D0
+     do i = 1, ntarget
+         area_target_total = area_target_total + area_target(i)
+         vol_target_un     = vol_target_un + terr_target(i) * area_target(i)
+     end do
+     write(*,*) "Global mean elevation (unfiltered):", &
+                 vol_target_un / area_target_total, " Total volume:", &
+                 vol_target_un, " Total area:", area_target_total
+     
     !
     ! diagnostics
     !
@@ -1320,7 +1520,7 @@ program convterr
     terr_target=0.0
     sgh_target=0.0
     sgh_uf_target=0.0
-    do counti=1,jall
+    do counti=1_i8,jall
       
       i   = weights_lgr_index_all(counti)
       ix  = weights_eul_index_all(counti,1)
@@ -1414,7 +1614,7 @@ program convterr
 
     if (lwrite_rrfac_to_topo_file) then
       rrfac_target = 0.0_r8
-      do counti=1,jall
+      do counti=1_i8,jall
         
         i   = weights_lgr_index_all(counti)
         ix  = weights_eul_index_all(counti,1)
@@ -1436,6 +1636,7 @@ program convterr
         
         rrfac_target  (i) = rrfac_target  (i) + wt*rrfac(ix,iy,ip)/area_target(i)
       end do
+       where(rrfac_target < 1.0) rrfac_target = 1.0
     end if
     DEALLOCATE(weights_all,weights_eul_index_all)
     
@@ -1501,22 +1702,44 @@ program convterr
     !**********************************************************************************************************************************
     if (lphis_gll) then
       call read_target_grid(grid_descriptor_fname_gll,lregional_refinement,ltarget_latlon,lpole,nlat,nlon,ntarget,ncorner,nrank,&
-           target_corner_lon, target_corner_lat, target_center_lon, target_center_lat, target_area, target_rrfac)
+           target_corner_lon, target_corner_lat, target_center_lon, target_center_lat, target_area, target_rrfac, grid_fallback_mask)
 
+        ! Identify and fix invalid coordinates (fully zeroed cells)
+        do icell = 1, ntarget
+            if (all(target_corner_lon(:, icell) == 0.0d0) .and. &
+                all(target_corner_lat(:, icell) == 0.0d0)) then
+                write(*,*) "GLL Fully invalid coordinates detected at cell:", icell
+                write(*,*) "Attempting to replace with neighbor coordinates..."
+        
+                if (icell < ntarget .and. .not. all(target_corner_lon(:, icell+1) == 0.0d0)) then
+                    target_corner_lon(:, icell) = target_corner_lon(:, icell+1)
+                    target_corner_lat(:, icell) = target_corner_lat(:, icell+1)
+                    write(*,*) "Cell", icell, "replaced with cell", icell+1
+                elseif (icell > 1 .and. .not. all(target_corner_lon(:, icell-1) == 0.0d0)) then
+                    target_corner_lon(:, icell) = target_corner_lon(:, icell-1)
+                    target_corner_lat(:, icell) = target_corner_lat(:, icell-1)
+                    write(*,*) "Cell", icell, "replaced with cell", icell-1
+                else
+                    write(*,*) "FATAL ERROR: No valid neighbors for cell:", icell
+                    STOP "Unable to repair invalid coordinates"
+                endif
+            endif
+        enddo
       allocate (terr_target(ntarget))
       if (linterp_phis) then
         CALL bilinear_interp(ncube,ntarget,target_center_lon,target_center_lat,terr_sm(1:ncube,1:ncube,:),terr_target)
       else
         jall = 0   ! dynamic fill again for GLL grid
         
-        write(*,*) "Compute overlap weights for GLL grid: "
-        CALL overlap_weights(weights_lgr_index_all,weights_eul_index_all,weights_all,&
-             jall,ncube,ngauss,ntarget,ncorner,jmax_segments,target_corner_lon,target_corner_lat,nreconstruction,ldbg)
+         CALL overlap_weights(weights_lgr_index_all,weights_eul_index_all,weights_all,&
+                     jall,ncube,ngauss,ntarget,ncorner,jmax_segments,target_corner_lon,target_corner_lat,&
+                     nreconstruction,ldbg,target_center_lon,target_center_lat,area_target,valid_cells,&
+                     num_lon_blocks,num_lat_blocks,lon_block_size,lat_block_size,blocks)
         
         allocate (area_target(ntarget))
         
         area_target = 0.0
-        do counti=1,jall
+        do counti=1_i8,jall
           i    = weights_lgr_index_all(counti)
           wt = weights_all(counti,1)
           area_target        (i) = area_target(i) + wt
@@ -1534,8 +1757,6 @@ program convterr
         ! >>> Bounds check <<<
          if (ix < 1 .or. ix > ncube .or. iy < 1 .or. iy > ncube .or. &
             ip < 1 .or. ip > 6) then
-            !if (ldbg_rr) write(*,*) 'ERROR: Invalid indices in TERRAIN map: ', counti, &
-           !           ' ix=', ix, ' iy=', iy, ' ip=', ip
            cycle  ! 'cycle' to skip
          end if
           

--- a/cube_to_target/cube_to_target.F90
+++ b/cube_to_target/cube_to_target.F90
@@ -1213,7 +1213,7 @@ program convterr
            write(*,*) "WARNING: very small jmax_segments estimated =", seg_est
            jmax_segments = 10000
          else
-           jmax_segments = MIN(50000, seg_est)
+           jmax_segments = MIN(5000000, seg_est)
          end if
        end if
    
@@ -1227,7 +1227,7 @@ program convterr
            write(*,*) "WARNING: invalid or too small da_min_target =", da_min_target
            jmax_segments = 10000
          else
-           jmax_segments = MIN(50000, seg_est)
+           jmax_segments = MIN(5000000, seg_est)
          end if
          write(*,*) "FINAL jmax_segments =", jmax_segments
        else

--- a/cube_to_target/cube_to_target.F90
+++ b/cube_to_target/cube_to_target.F90
@@ -6,6 +6,7 @@
 !  Author: Peter Hjort Lauritzen (pel@ucar.edu), AMP/CGD/NCAR 
 !          Julio Bacmeister, AMP/CGD/NCAR 
 !          Adam Herrington, AMP/CGD/NCAR
+!          NASA GMAO Modelling group edits 
 !
 ! ex: ./cube_to_target --help to get list of long and short option names.
 
@@ -705,7 +706,7 @@ program convterr
       opts(3)%specified = .true.
     case( 'h' )
       call print_help
-      opts(4)%specified = .true.
+      stop 0
     case( 'i' )
       intermediate_cubed_sphere_fname = optarg
       write(str,*) TRIM(optarg)
@@ -1377,16 +1378,12 @@ program convterr
   write(*,*) "            Difference       = ",(volterr - volterr_sm)/(6*sum(da))
  
 !------------------------------------------------------------
-! Optional global-volume correction after smoothing
-!
+!       Global-volume correction after smoothing
 !  Smoothing diffuses peaks more than it fills valleys, so the
 !  integrated terrain volume (and mean PHIS) usually drops a
 !  bit.  The line below rescales the smoothed field so that its
-!  volume matches the original.  Enable it if your downstream
-!  model needs strict preservation of global mean height.
-!
+!  volume matches the original. 
 !  terr_sm = (volterr / volterr_sm) * terr_sm
-!
 !------------------------------------------------------------  
 
   if (ldistance_weighted_smoother .or. lregional_refinement) then
@@ -2005,7 +2002,6 @@ program convterr
   !
   !
   !+++ARH
-  !subroutine wrtncdf_unstructured(n,terr,landfrac,sgh,sgh30,landm_coslat,lon,lat,area,output_fname,lfind_ridges)
   subroutine wrtncdf_unstructured(n,terr,landfrac,sgh,sgh30,landm_coslat,lon,lat,area,&
        output_fname,lfind_ridges,command_line_arguments,&
        lwrite_rrfac_to_topo_file,rrfac_target,str_creator,area_target,llandfrac)
@@ -2046,7 +2042,6 @@ program convterr
     integer            :: latvid
     integer            :: terrid, areaid!,nid
     !+++ARH
-    !integer            :: landfracid,sghid,sgh30id,landm_coslatid
     integer            :: landfracid,sghid,sgh30id,landm_coslatid
     !---ARH
     integer             :: mxdisid, ang22id, anixyid, anisoid, mxvrxid, mxvryid, hwdthid, wghtsid, anglxid, gbxarid
@@ -2054,7 +2049,6 @@ program convterr
     integer             :: ThisId
     
     integer            :: status    ! return value for error control of netcdf routin
-    !  integer, dimension(2) :: nc_lat_vid,nc_lon_vid
     character (len=8)  :: datestring
     integer, dimension(2) :: nid
     
@@ -2065,7 +2059,6 @@ program convterr
     !  Create NetCDF file for output
     !
     print *,"Create NetCDF file for output"
-    !status = nf_create (trim(output_fname), NF_64BIT_DATA, foutid)
     status = nf_create (trim(output_fname), NF_NETCDF4, foutid)
     if (status .ne. NF_NOERR) call handle_err(status)
     !

--- a/cube_to_target/cube_to_target.F90
+++ b/cube_to_target/cube_to_target.F90
@@ -525,8 +525,7 @@ program convterr
   integer                              :: count_fallback_clipped = 0
   
   logical, allocatable :: valid_cells(:)
-  real(r8) :: dist, min_dist, dlon, dlat
-  integer :: closest, j
+  integer :: closest 
 
   
   real(r8), allocatable, dimension(:,:) :: weights_all                        !overlap weights
@@ -572,7 +571,6 @@ program convterr
   !                             
   !                             for backwards compat with CESM2.0
   !                             Not used, 0 here for naming
-  integer :: nridge_subsample = 0 !
   !
   logical :: lridgetiles = .FALSE.
   
@@ -588,7 +586,7 @@ program convterr
   integer  :: smooth_phis_numcycle=-1
   real (r8):: smoothing_scale=0
   !
-  INTEGER :: UNIT, ioptarg
+  INTEGER ::  ioptarg
   
   INTEGER :: NSCL_f, NSCL_c, nhalo,nsw
 
@@ -607,7 +605,7 @@ program convterr
   character(len=1024) :: grid_descriptor_fname,intermediate_cubed_sphere_fname,output_fname=''
   character(len=1024) :: grid_descriptor_fname_gll
   character(len=1024) :: output_grid='', ofile,smooth_topo_fname = '',str_dir=''
-  character(len=1024) :: rrfactor_fname, command_line_arguments, str, str_creator, str_source=''
+  character(len=1024) :: command_line_arguments, str, str_creator, str_source=''
 
   character(len=8)  :: date
   character(len=10) :: time
@@ -666,7 +664,6 @@ program convterr
   opts(22) = option_s( "smooth_phis_numcycle"      ,.true.    , 'l'   ,.false.       ,.false.)
   opts(23) = option_s( "smoothing_over_ocean"      ,.false.   , 'm'   ,.false.       ,.false.)
   opts(24) = option_s( "jmax_segments"             ,.true.    , 'j'   ,.false.       ,.false.)
-  opts(25) = option_s( "use_block_neighbor_search" ,.false.    , 'w'  ,.false.       ,.false.)
  
   write(*,*)'bmaa hello' 
   ! END longopts
@@ -2008,13 +2005,9 @@ program convterr
     !---ARH
     use shared_vars, only : rad2deg
     use shr_kind_mod, only: r8 => shr_kind_r8
-    use shared_vars, only : terr_uf_target, sgh_uf_target
-    use ridge_ana, only: nsubr, mxdis_target, mxvrx_target, mxvry_target, ang22_target, &
-         anglx_target, aniso_target, anixy_target, hwdth_target, wghts_target, & 
-         clngt_target, cwght_target, count_target,riseq_target,grid_length_scale, &
-         fallq_target, isovar_target
-    
-    
+    use ridge_ana, only: nsubr, mxdis_target, ang22_target,   &
+         anglx_target, aniso_target, anixy_target, hwdth_target,  & 
+         clngt_target,  riseq_target, fallq_target 
     
     implicit none
     
@@ -2053,8 +2046,6 @@ program convterr
     integer, dimension(2) :: nid
     
     real(r8), parameter :: fillvalue = 1.d36
-    character(len=1024) :: str
-    
     !
     !  Create NetCDF file for output
     !
@@ -2531,9 +2522,6 @@ program convterr
     integer, dimension(2) :: nid
     
     real(r8), parameter :: fillvalue = 1.d36
-    character(len=1024) :: str
-    
-    
     !
     !  Create NetCDF file for output
     !
@@ -3273,11 +3261,10 @@ program convterr
     REAL(R8), DIMENSION(ncube,ncube,6), INTENT(IN) :: terr_cube
     REAL(R8), DIMENSION(ntarget),       INTENT(OUT):: terr_target
     
-    REAL(R8)                           :: lat, lon
     REAL(R8), DIMENSION(1:ncube+1)     :: xgno, ygno
     
     REAL(R8) :: da, alpha, beta, piq
-    INTEGER  :: i,ip,jx,jy,nhalo
+    INTEGER  :: i,ip,jx,jy
 
 !    REAL(R8), DIMENSION(0:ncube+1,0:ncube+1,6) :: terr_cube_halo
     real(r8) :: x,y,x1,x2,y1,y2,w11,w12,w21,w22 !variables for bi-linear interpolation
@@ -3325,7 +3312,7 @@ program convterr
   !------------------------------------------------------------------------------
   SUBROUTINE CubedSphereABPFromRLL(lon, lat, alpha, beta, ipanel, ldetermine_panel)
     use shr_kind_mod, only: r8 => shr_kind_r8
-    use shared_vars, only: rotate_cube, pi, piq
+    use shared_vars, only: rotate_cube
     IMPLICIT NONE
     
     REAL    (R8), INTENT(IN)  :: lon, lat

--- a/cube_to_target/cube_to_target.F90
+++ b/cube_to_target/cube_to_target.F90
@@ -532,6 +532,10 @@ program convterr
   integer :: icorner, icell
   integer :: iblock, jblock
 
+  integer(kind=8) :: tclock1, tclock2, clock_rate
+  real(kind=8) :: elapsed_time
+  call system_clock(tclock1)
+
 
   !               
   !                     long name                   has     | short | specified    | required
@@ -1792,6 +1796,11 @@ program convterr
       CALL wrtncdf_unstructured_append_phis(ntarget,terr_target, &
            target_center_lon,target_center_lat,output_fname)
     end if
+
+   call system_clock(tclock2, clock_rate)
+   elapsed_time = real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8)
+   print *, 'Elapsed time program convterr = ', elapsed_time, ' seconds.'
+
     end program convterr
 
    subroutine print_help

--- a/cube_to_target/cube_to_target.F90
+++ b/cube_to_target/cube_to_target.F90
@@ -1588,6 +1588,8 @@ program convterr
          deallocate(blocks)
          end if
          deallocate(valid_cells)
+       
+         call destroy_kdtree(tree)  ! free up resources for k-d tree
      
          write(*,*) "Fallback terrain adjustments applied in", count_fallback_clipped, "cells."
      end if
@@ -1945,6 +1947,8 @@ program convterr
       end if
       CALL wrtncdf_unstructured_append_phis(ntarget,terr_target, &
            target_center_lon,target_center_lat,output_fname)
+
+      call destroy_kdtree(tree)  ! free up resources for k-d tree
     end if
 
    call system_clock(tclock2, clock_rate)

--- a/cube_to_target/cube_to_target.F90
+++ b/cube_to_target/cube_to_target.F90
@@ -1669,8 +1669,6 @@ program convterr
       IF (sgh_target(i)     <    0.5)  sgh_target(i)       = 0.0D0
       IF (sgh30_target(i)<       0.5D0) sgh30_target(i)    = 0.0D0
     END DO
-    sgh30_target = SQRT(sgh30_target)
-    sgh_target = SQRT(sgh_target)
     
     WRITE(*,*) "min/max of terr source                   : ",MINVAL(terr),MAXVAL(terr)
     WRITE(*,*) "min/max of terr_target                   : ",MINVAL(terr_target    ),MAXVAL(terr_target    )

--- a/cube_to_target/cube_to_target.F90
+++ b/cube_to_target/cube_to_target.F90
@@ -319,7 +319,6 @@ CONTAINS
               else  ! use k-d tree search
                  closest = find_nearest_neighbor_kdtree(tree, target_center_lon(i), target_center_lat(i), i)
              end if
-             write(100,*) i, target_center_lon(i), target_center_lat(i), closest
              call system_clock(tclock2, clock_rate)
              elapsed_time_clsst = elapsed_time_clsst + (real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8))
               if (mod(i,100000) == 0) print '(a, i12, i4, e16.6)', 'Elapsed time compute_clsst = ', i, ip, elapsed_time_clsst
@@ -942,7 +941,6 @@ program convterr
               else ! use k-d tree search
                  closest = find_nearest_neighbor_kdtree(tree, target_center_lon(icell), target_center_lat(icell), icell)
               end if
-             write(200,*) i, target_center_lon(i), target_center_lat(i), closest
       
               if (closest > 0) then
                   target_corner_lon(:, icell) = target_corner_lon(:, closest)
@@ -1261,7 +1259,7 @@ program convterr
                      nreconstruction,ldbg,target_center_lon,target_center_lat,area_target,valid_cells,&
                      num_lon_blocks,num_lat_blocks,lon_block_size,lat_block_size,blocks,tree,use_block_neighbor_search)
   
-     write(*,*) "DEBUG 1: Finished overlap_weights subroutine call"   
+     write(*,*) "DEBUG : Finished overlap_weights subroutine call"   
 
      deallocate(target_corner_lon,target_corner_lat)
    end if
@@ -1534,7 +1532,6 @@ program convterr
               else ! use k-d tree search
                  closest = find_nearest_neighbor_kdtree(tree, target_center_lon(icell), target_center_lat(icell), icell)
               end if
-             write(300,*) i, target_center_lon(i), target_center_lat(i), closest
                  if (closest > 0) then
                      ! Check validity of neighbor terrain height
                      if (terr_target(closest) > 8848.0d0 .or. terr_target(closest) < -423.0d0) then
@@ -1582,12 +1579,15 @@ program convterr
          end do
      
          ! Cleanup
+         if (use_block_neighbor_search) then
          do iblock = 1, num_lon_blocks
              do jblock = 1, num_lat_blocks
                  deallocate(blocks(iblock, jblock)%indices)
              end do
          end do
-         deallocate(blocks, valid_cells)
+         deallocate(blocks)
+         end if
+         deallocate(valid_cells)
      
          write(*,*) "Fallback terrain adjustments applied in", count_fallback_clipped, "cells."
      end if

--- a/cube_to_target/cube_to_target.F90
+++ b/cube_to_target/cube_to_target.F90
@@ -42,12 +42,13 @@ CONTAINS
    SUBROUTINE overlap_weights(weights_lgr_index_all,weights_eul_index_all,weights_all,&
              jall,ncube,ngauss,ntarget,ncorner,jmax_segments,target_corner_lon,target_corner_lat,&
               nreconstruction,ldbg,target_center_lon,target_center_lat,area_target,valid_cells,&
-              num_lon_blocks,num_lat_blocks,lon_block_size,lat_block_size,blocks)
+              num_lon_blocks,num_lat_blocks,lon_block_size,lat_block_size,blocks,tree,use_block_neighbor_search)
 
     use shr_kind_mod, only: r8 => shr_kind_r8,i8 => shr_kind_i8
     use remap
     use shared_vars, only: progress_bar
     use neighbor_search_mod, ONLY: BlockType, find_nearest_valid_neighbor
+    use kdtree_mod
     IMPLICIT NONE
 
     !----------------------------------------------------------------------
@@ -67,6 +68,8 @@ CONTAINS
     REAL   (r8),                    INTENT(IN)    :: target_corner_lon(ncorner,ntarget)
     REAL   (r8),                    INTENT(IN)    :: target_corner_lat(ncorner,ntarget)
     LOGICAL,                        INTENT(IN)    :: ldbg
+    type(kdtree),                   INTENT(IN)    :: tree
+    LOGICAL,           INTENT(IN)    :: use_block_neighbor_search
     !----------------------------------------------------------------------
     !  Local scalars / arrays
     !----------------------------------------------------------------------
@@ -136,9 +139,12 @@ CONTAINS
 
     jall = 0
 
-
     DO i=1,ntarget
 
+      block
+      integer(kind=8) :: tclock1, tclock2, clock_rate
+      real(kind=8), save :: elapsed_time_target = 0.d0
+      call system_clock(tclock1)
 
       !if (MOD(i,10)==0)call progress_bar("# ", i, DBLE(100*i)/DBLE(ntarget))  !commented out b/c log to large
       !
@@ -148,8 +154,16 @@ CONTAINS
       !
       !---------------------------------------------------
       !
+      rmv_dupl: block
+      integer(kind=8) :: tclock1, tclock2, clock_rate
+      real(kind=8), save :: elapsed_time_rmvd = 0.d0
+      call system_clock(tclock1)
       CALL remove_duplicates_latlon(ncorner,target_corner_lon(:,i),target_corner_lat(:,i),&
            ncorner_this_cell,lon,lat,1.0E-10)
+      call system_clock(tclock2, clock_rate)
+      elapsed_time_rmvd = elapsed_time_rmvd + (real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8))
+       if (mod(i,100000) == 0) print '(a, i12, e16.6)', 'Elapsed time rmvd = ', i, elapsed_time_rmvd
+       end block rmv_dupl
 
       IF (ldbg) THEN
         WRITE(*,*) "number of vertices ",ncorner_this_cell
@@ -168,6 +182,10 @@ CONTAINS
       !---------------------------------------------------          
       !
 #ifdef old    
+      dold: block
+      integer(kind=8) :: tclock1, tclock2, clock_rate
+      real(kind=8), save :: elapsed_time_dold = 0.d0
+      call system_clock(tclock1)
       DO j=1,ncorner_this_cell
         CALL CubedSphereABPFromRLL(lon(j), lat(j), alpha, beta, ipanel_tmp(j), .TRUE.)
         IF (ldbg) WRITE(*,*) "ipanel for corner ",j," is ",ipanel_tmp(j)
@@ -186,10 +204,18 @@ CONTAINS
       END IF
       CALL remove_duplicates_integer(ncorner_this_cell+1,ipanel_tmp(1:ncorner_this_cell+1),&
            k,ipanel_array(1:ncorner_this_cell+1))
+      call system_clock(tclock2, clock_rate)
+      elapsed_time_dold = elapsed_time_dold + (real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8))
+       if (mod(i,100000) == 0) print '(a, i12, e16.6)', 'Elapsed time dold = ', i, elapsed_time_dold
+       end block dold
 #endif
       !
       ! make sure to include possible overlap areas not on the face the vertices are located
       ! For example, a cell could be on panel 3 and 5 but have overlap area on panel 2
+      CSABPF: block
+      integer(kind=8) :: tclock1, tclock2, clock_rate
+      real(kind=8), save :: elapsed_time_CSABPF = 0.d0
+      call system_clock(tclock1)
       count = 0
       do ilat=-1,1
         do ilon=-1,1
@@ -199,12 +225,24 @@ CONTAINS
           END DO
         end do
       end do
+      call system_clock(tclock2, clock_rate)
+      elapsed_time_CSABPF = elapsed_time_CSABPF + (real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8))
+       if (mod(i,100000) == 0) print '(a, i12, e16.6)', 'Elapsed time CSABPF = ', i, elapsed_time_CSABPF
+       end block CSABPF
 
       !
       ! remove duplicates in ipanel_tmp
       !
+      rmv_dupli: block
+      integer(kind=8) :: tclock1, tclock2, clock_rate
+      real(kind=8), save :: elapsed_time_rmvdi = 0.d0
+      call system_clock(tclock1)
       CALL remove_duplicates_integer(count,ipanel_tmp(1:count),&
            k,ipanel_array(1:count))
+      call system_clock(tclock2, clock_rate)
+      elapsed_time_rmvdi = elapsed_time_rmvdi + (real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8))
+       if (mod(i,100000) == 0) print '(a, i12, e16.6)', 'Elapsed time rmvdi = ', i, elapsed_time_rmvdi
+       end block rmv_dupli
       !
       !---------------------------------------------------
       !
@@ -214,6 +252,10 @@ CONTAINS
       !
       DO ip = 1,k
         ipanel = ipanel_array(ip)
+        CSABPF2: block
+        integer(kind=8) :: tclock1, tclock2, clock_rate
+        real(kind=8), save :: elapsed_time_CSABPF2 = 0.d0
+        call system_clock(tclock1)
         DO j=1,ncorner_this_cell
           ii = ipanel
           CALL CubedSphereABPFromRLL(lon(j), lat(j), alpha, beta, ii,.FALSE.)
@@ -224,6 +266,10 @@ CONTAINS
           xcell(ncorner_this_cell+1-j) = TAN(alpha)
           ycell(ncorner_this_cell+1-j) = TAN(beta)
         END DO
+        call system_clock(tclock2, clock_rate)
+        elapsed_time_CSABPF2 = elapsed_time_CSABPF2 + (real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8))
+         if (mod(i,100000) == 0) print '(a, i12, i4, e16.6)', 'Elapsed time CSABPF2 = ', i, ip, elapsed_time_CSABPF2
+         end block CSABPF2
         xcell(0) = xcell(ncorner_this_cell)
         ycell(0) = ycell(ncorner_this_cell)
         xcell(ncorner_this_cell+1) = xcell(1)
@@ -232,11 +278,19 @@ CONTAINS
         jx = MAX(MIN(jx,ncube+1),0)
         jy = MAX(MIN(jy,ncube+1),0)
 
+        compute_wt: block 
+        integer(kind=8) :: tclock1, tclock2, clock_rate
+        real(kind=8), save :: elapsed_time_cwtall = 0.d0
+        call system_clock(tclock1)
         CALL compute_weights_cell(xcell(0:ncorner_this_cell+1),ycell(0:ncorner_this_cell+1),&
              jx,jy,nreconstruction,xgno,ygno,&
              1, ncube+1, 1,ncube+1, tmp,&
              ngauss,gauss_weights,abscissae,weights,weights_eul_index,jcollect,jmax_segments,&
              ncube,0,ncorner_this_cell,ldbg,i)
+         call system_clock(tclock2, clock_rate)
+         elapsed_time_cwtall = elapsed_time_cwtall + (real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8))
+          if (mod(i,100000) == 0) print '(a, i12, i4, e16.6)', 'Elapsed time compute_wtsc = ', i, ip, elapsed_time_cwtall
+         end block compute_wt
 
          if (jcollect <= 0 .or. sum(weights(1:jcollect, 1)) < 1.0d-12) then
          
@@ -254,10 +308,27 @@ CONTAINS
                  write(*,*) "lon_block_size:", lon_block_size, "lat_block_size:", lat_block_size
              endif
          
-             closest = find_nearest_valid_neighbor(i, target_center_lon, target_center_lat, valid_cells, &
-                                                   num_lon_blocks, num_lat_blocks, lon_block_size, lat_block_size, &
-                                                   blocks, 10)
+             clsst: block 
+             integer(kind=8) :: tclock1, tclock2, clock_rate
+             real(kind=8), save :: elapsed_time_clsst = 0.d0
+             call system_clock(tclock1)
+              if (use_block_neighbor_search) then
+                 closest = find_nearest_valid_neighbor(i, target_center_lon, target_center_lat, valid_cells, &
+                                                  num_lon_blocks, num_lat_blocks, lon_block_size, lat_block_size, &
+                                                  blocks, 10)
+              else  ! use k-d tree search
+                 closest = find_nearest_neighbor_kdtree(tree, target_center_lon(i), target_center_lat(i), i)
+             end if
+             write(100,*) i, target_center_lon(i), target_center_lat(i), closest
+             call system_clock(tclock2, clock_rate)
+             elapsed_time_clsst = elapsed_time_clsst + (real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8))
+              if (mod(i,100000) == 0) print '(a, i12, i4, e16.6)', 'Elapsed time compute_clsst = ', i, ip, elapsed_time_clsst
+             end block clsst
          
+             ensure_cap0: block
+             integer(kind=8) :: tclock1, tclock2, clock_rate
+             real(kind=8), save :: elapsed_time_ensc0 = 0.d0
+             call system_clock(tclock1)
              if (closest > 0) then
                  if (.not.allocated(weights_all) .or. SIZE(weights_all,1) < jall + 1) then
                      CALL ensure_capacity(INT(1024, i8), jall, nreconstruction, &
@@ -274,6 +345,10 @@ CONTAINS
              else if (print_limited) then
                  write(*,*) "No valid neighbor found for cell", i
              endif
+             call system_clock(tclock2, clock_rate)
+             elapsed_time_ensc0 = elapsed_time_ensc0 + (real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8))
+             if (mod(i,100000) == 0) print '(a, i12, i4, e16.6)', 'Elapsed time  ensure_cap = ', i, ip, elapsed_time_ensc0
+             end block ensure_cap0
             ! Skip the rest of processing since you've handled it explicitly
              cycle
          endif
@@ -292,23 +367,44 @@ CONTAINS
         ENDIF
 
 
+       ensure_cap: block
+       integer(kind=8) :: tclock1, tclock2, clock_rate
+       real(kind=8), save :: elapsed_time_ensc = 0.d0
+       call system_clock(tclock1)
        IF (.NOT. ALLOCATED(weights_all) .OR. &
            SIZE(weights_all,1) < jall + jcollect) THEN
          CALL ensure_capacity(INT(MAX(jcollect,1024), i8),jall, nreconstruction, &
                               weights_all, weights_eul_index_all, &
                               weights_lgr_index_all)
        END IF
+       call system_clock(tclock2, clock_rate)
+       elapsed_time_ensc = elapsed_time_ensc + (real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8))
+       if (mod(i,100000) == 0) print '(a, i12, i4, e16.6)', 'Elapsed time  ensure_cap = ', i, ip, elapsed_time_ensc
+       end block ensure_cap
 
 
+        weights_al: block
+       integer(kind=8) :: tclock1, tclock2, clock_rate
+       real(kind=8), save :: elapsed_time_wall = 0.d0
+       call system_clock(tclock1)
         weights_all(jall + 1 : jall + jcollect, :) = weights(1:jcollect,:)
         weights_eul_index_all(jall + 1 : jall + jcollect, 1:2) = weights_eul_index(1:jcollect,:)
         weights_eul_index_all(jall + 1 : jall + jcollect, 3) = ipanel
         weights_lgr_index_all(jall + 1 : jall + jcollect) = i
+       call system_clock(tclock2, clock_rate)
+       elapsed_time_wall = elapsed_time_wall + (real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8))
+       if (mod(i,100000) == 0) print '(a, i12, i4, e16.6)', 'Elapsed time weights_all = ', i, ip, elapsed_time_wall
+        end block weights_al
 
         jall = jall + jcollect
 
       END DO
+      call system_clock(tclock2, clock_rate)
+      elapsed_time_target = elapsed_time_target + (real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8))
+       if (mod(i,100000) == 0) print '(a, i12, e16.6)', 'Elapsed time target = ', i, elapsed_time_target
+      end block
     END DO
+
 
     !====================================================================
     !  ensure_capacity  – dynamically (re)allocates the three big weight
@@ -401,6 +497,7 @@ program convterr
   use f90getopt
   use overlap_mod
   USE neighbor_search_mod, ONLY: BlockType, find_nearest_valid_neighbor
+  use kdtree_mod
   
   implicit none
 #     include         <netcdf.inc>
@@ -532,6 +629,10 @@ program convterr
   integer :: icorner, icell
   integer :: iblock, jblock
 
+  logical :: use_block_neighbor_search = .false. ! set this to true for block neigbor search instead of the fast k-d tree appraoch
+
+  type(kdtree) :: tree
+
   integer(kind=8) :: tclock1, tclock2, clock_rate
   real(kind=8) :: elapsed_time
   call system_clock(tclock1)
@@ -565,6 +666,7 @@ program convterr
   opts(22) = option_s( "smooth_phis_numcycle"      ,.true.    , 'l'   ,.false.       ,.false.)
   opts(23) = option_s( "smoothing_over_ocean"      ,.false.   , 'm'   ,.false.       ,.false.)
   opts(24) = option_s( "jmax_segments"             ,.true.    , 'j'   ,.false.       ,.false.)
+  opts(25) = option_s( "use_block_neighbor_search" ,.false.    , 'w'  ,.false.       ,.false.)
  
   write(*,*)'bmaa hello' 
   ! END longopts
@@ -778,26 +880,50 @@ program convterr
 
       allocate(valid_cells(ntarget))
       valid_cells = (grid_fallback_mask /= 1)
-      
-      ! Allocate valid_cells and populate blocks immediately after reading the grid:
-      allocate(blocks(num_lon_blocks, num_lat_blocks))
-      do iblock = 1, num_lon_blocks
-          do jblock = 1, num_lat_blocks
-              blocks(iblock, jblock)%num_cells = 0
-              allocate(blocks(iblock, jblock)%indices(0))
-          end do
-      end do
-
-      ! Populate valid cells into blocks
       do icell = 1, ntarget
-          if (valid_cells(icell)) then
-              iblock = min(num_lon_blocks, max(1, int(target_center_lon(icell) / lon_block_size) + 1))
-              jblock = min(num_lat_blocks, max(1, int((target_center_lat(icell) + 90.0d0) / lat_block_size) + 1))
-  
-              blocks(iblock, jblock)%num_cells = blocks(iblock, jblock)%num_cells + 1
-              blocks(iblock, jblock)%indices = [blocks(iblock, jblock)%indices, icell]
+          if (all(target_corner_lon(:, icell) == 0.0d0) .and. &
+              all(target_corner_lat(:, icell) == 0.0d0)) then 
+      
+              write(*,*) "Fully invalid coordinates detected at cell:", icell
+              valid_cells(icell) = .false.  ! mark as invalid immediately
           end if
       end do
+      
+      ! Allocate valid_cells and populate blocks immediately after reading the grid:
+      if (use_block_neighbor_search) then
+          allocate(blocks(num_lon_blocks, num_lat_blocks))
+          do iblock = 1, num_lon_blocks
+              do jblock = 1, num_lat_blocks
+                  blocks(iblock, jblock)%num_cells = 0
+                  allocate(blocks(iblock, jblock)%indices(0))
+              end do
+          end do
+
+          ! Populate valid cells into blocks
+          do icell = 1, ntarget
+              if (valid_cells(icell)) then
+                  iblock = min(num_lon_blocks, max(1, int(target_center_lon(icell) / lon_block_size) + 1))
+                  jblock = min(num_lat_blocks, max(1, int((target_center_lat(icell) + 90.0d0) / lat_block_size) + 1))
+  
+                  blocks(iblock, jblock)%num_cells = blocks(iblock, jblock)%num_cells + 1
+                  blocks(iblock, jblock)%indices = [blocks(iblock, jblock)%indices, icell]
+              end if
+          end do
+
+      else  ! use k-d tree
+
+          b_kdtree: block
+          integer(kind=8) :: tclock1, tclock2, clock_rate
+          real(kind=8) :: elapsed_time_bkdt
+          call system_clock(tclock1)
+          print *, 'HERE in build kd tree ... ', __LINE__
+          call build_kdtree(tree, target_center_lon, target_center_lat, valid_cells)
+          call system_clock(tclock2, clock_rate)
+          elapsed_time_bkdt = (real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8))
+           print '(a, e16.6)', 'Elapsed time bkdt = ', elapsed_time_bkdt
+          end block b_kdtree
+
+      end if ! use_block_neighbor_search
 
       ! Identify and fix invalid coordinates (fully zeroed cells)
       do icell = 1, ntarget
@@ -808,9 +934,15 @@ program convterr
               valid_cells(icell) = .false.  ! mark as invalid immediately
       
               ! Robust fix using find_nearest_valid_neighbor
-              closest = find_nearest_valid_neighbor(icell, target_center_lon, target_center_lat, valid_cells, &
+
+              if (use_block_neighbor_search) then
+                 closest = find_nearest_valid_neighbor(icell, target_center_lon, target_center_lat, valid_cells, &
                                                     num_lon_blocks, num_lat_blocks, lon_block_size, lat_block_size, &
                                                     blocks, 100)
+              else ! use k-d tree search
+                 closest = find_nearest_neighbor_kdtree(tree, target_center_lon(icell), target_center_lat(icell), icell)
+              end if
+             write(200,*) i, target_center_lon(i), target_center_lat(i), closest
       
               if (closest > 0) then
                   target_corner_lon(:, icell) = target_corner_lon(:, closest)
@@ -841,7 +973,7 @@ program convterr
     allocate (area_target(ntarget),stat=alloc_error )
     area_target = 0.0
 
-  end if
+  end if   !.not.lstop_after_smoothing
 
   if (maxval(target_rrfac)/minval(target_rrfac)<1.5) then
     write(*,*) "rrfac specified but little variation: max(rrfac)/min(rrfac)=",maxval(target_rrfac)/minval(target_rrfac)
@@ -1127,9 +1259,9 @@ program convterr
       CALL overlap_weights(weights_lgr_index_all,weights_eul_index_all,weights_all,&
                      jall,ncube,ngauss,ntarget,ncorner,jmax_segments,target_corner_lon,target_corner_lat,&
                      nreconstruction,ldbg,target_center_lon,target_center_lat,area_target,valid_cells,&
-                     num_lon_blocks,num_lat_blocks,lon_block_size,lat_block_size,blocks)
+                     num_lon_blocks,num_lat_blocks,lon_block_size,lat_block_size,blocks,tree,use_block_neighbor_search)
   
-     write(*,*) "DEBUG: Finished overlap_weights subroutine call"   
+     write(*,*) "DEBUG 1: Finished overlap_weights subroutine call"   
 
      deallocate(target_corner_lon,target_corner_lat)
    end if
@@ -1334,7 +1466,8 @@ program convterr
                                            nreconstruction, ntarget, target_center_lon, &
                                            target_center_lat, valid_cells, &
                                            num_lon_blocks, num_lat_blocks, &
-                                           lon_block_size, lat_block_size, blocks)
+                                           lon_block_size, lat_block_size, blocks, &
+                                           tree, use_block_neighbor_search)
     else
        terr_target = remap_field(terr, area_target, weights_eul_index_all, &
                                  weights_lgr_index_all, weights_all, ncube, jall, &
@@ -1394,9 +1527,14 @@ program convterr
              if (grid_fallback_mask(icell) == 1) then
                  original_terrain = terr_target(icell)
      
+              if (use_block_neighbor_search) then
                  closest = find_nearest_valid_neighbor(icell, target_center_lon, target_center_lat, valid_cells, &
                                                        num_lon_blocks, num_lat_blocks, lon_block_size, lat_block_size, &
                                                        blocks, 10)
+              else ! use k-d tree search
+                 closest = find_nearest_neighbor_kdtree(tree, target_center_lon(icell), target_center_lat(icell), icell)
+              end if
+             write(300,*) i, target_center_lon(i), target_center_lat(i), closest
                  if (closest > 0) then
                      ! Check validity of neighbor terrain height
                      if (terr_target(closest) > 8848.0d0 .or. terr_target(closest) < -423.0d0) then
@@ -1737,11 +1875,25 @@ program convterr
         CALL bilinear_interp(ncube,ntarget,target_center_lon,target_center_lat,terr_sm(1:ncube,1:ncube,:),terr_target)
       else
         jall = 0   ! dynamic fill again for GLL grid
+
+        if (.not. use_block_neighbor_search) then
+           b_kdtree2: block
+           integer(kind=8) :: tclock1, tclock2, clock_rate
+           real(kind=8) :: elapsed_time_bkdt
+           call system_clock(tclock1)
+           print *, 'HERE in build kd tree ... ', __LINE__
+           call build_kdtree(tree, target_center_lon, target_center_lat, valid_cells)
+           call system_clock(tclock2, clock_rate)
+           elapsed_time_bkdt = (real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8))
+            print '(a, e16.6)', 'Elapsed time bkdt 2 = ', elapsed_time_bkdt
+           end block b_kdtree2
+        end if
         
          CALL overlap_weights(weights_lgr_index_all,weights_eul_index_all,weights_all,&
                      jall,ncube,ngauss,ntarget,ncorner,jmax_segments,target_corner_lon,target_corner_lat,&
                      nreconstruction,ldbg,target_center_lon,target_center_lat,area_target,valid_cells,&
-                     num_lon_blocks,num_lat_blocks,lon_block_size,lat_block_size,blocks)
+                     num_lon_blocks,num_lat_blocks,lon_block_size,lat_block_size,blocks,tree,   &
+                     use_block_neighbor_search)
         
         allocate (area_target(ntarget))
         

--- a/cube_to_target/cube_to_target.F90
+++ b/cube_to_target/cube_to_target.F90
@@ -1296,15 +1296,23 @@ program convterr
     !********************************************************************
     
     !
-    ! Sum exchange grid cells within each target
-    ! grid cell
+    ! Sum exchange grid cells within each target grid cell
     !
     area_target = 0.0_r8  ! explicitly zero at start
     do counti=1_i8,jall
       i    = weights_lgr_index_all(counti)
       wt = weights_all(counti,1)
-      area_target(i) = max(area_target(i) + wt, 1e-12_r8)
+      area_target(i) = area_target(i) + wt
     end do
+
+    ! Explicit safeguard against tiny or negative areas, stretch and regular fine grid suffer 
+    ! from grid distortions even though geometry (vortex ordering) is correct. 
+    do i = 1, ntarget
+        if (area_target(i) < 1e-12_r8) then
+            area_target(i) = 1e-12_r8
+        endif
+    end do  
+
     write(*,*) "MIN/MAX area_target",MINVAL(area_target),MAXVAl(area_target)
     write(*,*) "MIN/MAX target_area",MINVAL(target_area),MAXVAl(target_area)
     
@@ -1457,6 +1465,7 @@ program convterr
          area_target_total = area_target_total + area_target(i)
          vol_target_un     = vol_target_un + terr_target(i) * area_target(i)
      end do
+         area_target_total = max(area_target_total, 1e-12_r8)
      write(*,*) "Global mean elevation (unfiltered):", &
                  vol_target_un / area_target_total, " Total volume:", &
                  vol_target_un, " Total area:", area_target_total
@@ -1744,6 +1753,13 @@ program convterr
           wt = weights_all(counti,1)
           area_target        (i) = area_target(i) + wt
         end do
+
+        ! Explicit safeguard against tiny or negative areas
+        do i = 1, ntarget
+            if (area_target(i) < 1e-12_r8) then
+                area_target(i) = 1e-12_r8
+            endif
+        end do        
         
         write(*,*) "Remapping terrain"
         

--- a/cube_to_target/cube_to_target.F90
+++ b/cube_to_target/cube_to_target.F90
@@ -8,14 +8,337 @@
 !          Adam Herrington, AMP/CGD/NCAR
 !
 ! ex: ./cube_to_target --help to get list of long and short option names.
+
+MODULE overlap_mod
+  USE shr_kind_mod, ONLY: r8 => shr_kind_r8
+  USE remap
+  USE shared_vars, ONLY: progress_bar
+  IMPLICIT NONE
+CONTAINS
+
+  !*******************************************************************************
+  !  At this point mapping arrays are calculated
+  !
+  !      weights_lgr_index_all: dimension(JALL). Index of target grid cell that contains
+  !                             current exchange grid cell
+  ! 
+  !      weights_eul_index_all: dimension(JALL,3). 3 indices of cubed-sphere grid cell that 
+  !                             contains current exchange grid cell:
+  !
+  !                                weights_eul_index_all(:,1) = x-index
+  !                                weights_eul_index_all(:,2) = y-index
+  !                                weights_eul_index_all(:,3) = panel/face number 1-6
+  !
+  !                             These are then converted to one-dimensional indices 
+  !                             for cubed sphere variables terr(n), ... etc. 
+  !
+  !      weights_all:           dimension(JALL,nreconstrunction). Spherical area of
+  !                             exchange grid cell (steradians)
+  !
+  !********************************************************************************
+
+  SUBROUTINE overlap_weights(weights_lgr_index_all,weights_eul_index_all,weights_all,&
+       jall,ncube,ngauss,ntarget,ncorner,jmax_segments,target_corner_lon,target_corner_lat,nreconstruction,ldbg)
+    use shr_kind_mod, only: r8 => shr_kind_r8,i8 => shr_kind_i8
+    use remap
+    use shared_vars, only: progress_bar
+    IMPLICIT NONE
+
+    !----------------------------------------------------------------------
+    !  Dummy arguments
+    !----------------------------------------------------------------------
+    INTEGER(i8),                    INTENT(INOUT) :: jall            ! # rows currently filled
+    INTEGER,                        INTENT(IN)    :: ncube, ngauss,  &
+                                                     ntarget,         &
+                                                     jmax_segments,   &
+                                                     ncorner,         &
+                                                     nreconstruction
+    ! Grow‑as‑you‑go exchange‑grid arrays (caller passed them in ALLOCATED)
+    REAL   (r8)  , ALLOCATABLE,     INTENT(INOUT) :: weights_all(:,:)           ! (rows , nreconstruction)
+    INTEGER      , ALLOCATABLE,     INTENT(INOUT) :: weights_eul_index_all(:,:) ! (rows , 3)
+    INTEGER      , ALLOCATABLE,     INTENT(INOUT) :: weights_lgr_index_all(:)   ! (rows)
+
+    REAL   (r8),                    INTENT(IN)    :: target_corner_lon(ncorner,ntarget)
+    REAL   (r8),                    INTENT(IN)    :: target_corner_lat(ncorner,ntarget)
+    LOGICAL,                        INTENT(IN)    :: ldbg
+    !----------------------------------------------------------------------
+    !  Local scalars / arrays
+    !----------------------------------------------------------------------
+    INTEGER,  DIMENSION(9*(ncorner+1)) :: ipanel_tmp, ipanel_array
+    REAL(r8), DIMENSION(ncorner)       :: lon, lat
+    REAL(r8), DIMENSION(0:ncube+2)     :: xgno, ygno
+    REAL(r8), DIMENSION(0:ncorner+1)   :: xcell, ycell
+    REAL(r8), DIMENSION(ngauss)        :: gauss_weights, abscissae
+
+    REAL(r8) :: da, tmp, alpha, beta, pi, piq, pih, rad2deg, deps
+    INTEGER  :: i, j, k, ip, ipanel, ii, jx, jy, jcollect, ncorner_this_cell
+    INTEGER  :: alloc_error, ilon, ilat, count
+    INTEGER(KIND=8)         :: jall_anticipated, jall_anticipated_8
+
+    ! Work arrays returned from compute_weights_cell
+    REAL   (r8)  , ALLOCATABLE :: weights(:,:)          ! (jmax_segments , nreconstruction)
+    INTEGER      , ALLOCATABLE :: weights_eul_index(:,:) ! (jmax_segments , 2)
+
+    pi = 4.D0*DATAN(1.D0)
+    piq = pi/4.D0
+    pih = pi*0.5D0
+    rad2deg = 180.D0/pi
+
+    deps = 10.0D0*pi/180.0_r8
+
+
+    jall_anticipated_8 = INT(ntarget, 8) * INT(jmax_segments, 8) * 3_8
+
+    IF (jall_anticipated_8 > HUGE(jall_anticipated)) THEN
+        WRITE(*,*) "WARNING: jall_anticipated exceeds INTEGER limit; truncating to 1080000000"
+        jall_anticipated = 1080000000
+    ELSE
+        jall_anticipated = jall_anticipated_8
+    END IF
+
+    ipanel_array = -99
+    !
+    da = pih/DBLE(ncube)
+    xgno(0) = -bignum
+    DO i=1,ncube+1
+      xgno(i) = TAN(-piq+(i-1)*da)
+    END DO
+    xgno(ncube+2) = bignum
+    ygno = xgno
+
+    CALL glwp(ngauss,gauss_weights,abscissae)
+
+    allocate (weights(jmax_segments,nreconstruction),stat=alloc_error )
+    allocate (weights_eul_index(jmax_segments,2),stat=alloc_error )
+
+    IF (alloc_error /= 0) THEN
+       WRITE(*,*) "ERROR: Allocation failed for weights arrays"
+       STOP
+    ENDIF
+
+
+    jall = 0
+
+
+    DO i=1,ntarget
+
+
+      !if (MOD(i,10)==0)call progress_bar("# ", i, DBLE(100*i)/DBLE(ntarget))  !commented out b/c log to large
+      !
+      !---------------------------------------------------          
+      !
+      ! determine how many vertices the cell has
+      !
+      !---------------------------------------------------
+      !
+      CALL remove_duplicates_latlon(ncorner,target_corner_lon(:,i),target_corner_lat(:,i),&
+           ncorner_this_cell,lon,lat,1.0E-10)
+
+      IF (ldbg) THEN
+        WRITE(*,*) "number of vertices ",ncorner_this_cell
+        WRITE(*,*) "vertices locations lon,",lon(1:ncorner_this_cell)*rad2deg
+        WRITE(*,*) "vertices locations lat,",lat(1:ncorner_this_cell)*rad2deg
+        DO j=1,ncorner_this_cell
+          WRITE(*,*) lon(j)*rad2deg, lat(j)*rad2deg
+        END DO
+        WRITE(*,*) "  "
+      END IF
+      !
+      !---------------------------------------------------
+      !
+      ! determine how many and which panels the cell spans
+      !
+      !---------------------------------------------------          
+      !
+#ifdef old    
+      DO j=1,ncorner_this_cell
+        CALL CubedSphereABPFromRLL(lon(j), lat(j), alpha, beta, ipanel_tmp(j), .TRUE.)
+        IF (ldbg) WRITE(*,*) "ipanel for corner ",j," is ",ipanel_tmp(j)
+      END DO
+      ipanel_tmp(ncorner_this_cell+1) = ipanel_tmp(1)
+      ! make sure to include possible overlap areas not on the face the vertices are located
+      IF (MINVAL(lat(1:ncorner_this_cell))<-pi/6.0) THEN
+        ! include South-pole panel in search
+        ipanel_tmp(ncorner_this_cell+1) = 5
+        IF (ldbg) WRITE(*,*)  "add panel 5 to search"
+      END IF
+      IF (MAXVAL(lat(1:ncorner_this_cell))>pi/6.0) THEN
+        ! include North-pole panel in search
+        ipanel_tmp(ncorner_this_cell+1) = 6
+        IF (ldbg) WRITE(*,*)  "add panel 6 to search"
+      END IF
+      CALL remove_duplicates_integer(ncorner_this_cell+1,ipanel_tmp(1:ncorner_this_cell+1),&
+           k,ipanel_array(1:ncorner_this_cell+1))
+#endif
+      !
+      ! make sure to include possible overlap areas not on the face the vertices are located
+      ! For example, a cell could be on panel 3 and 5 but have overlap area on panel 2
+      count = 0
+      do ilat=-1,1
+        do ilon=-1,1
+          DO j=1,ncorner_this_cell
+            count=count+1
+            CALL CubedSphereABPFromRLL(lon(j)+ilon*deps, lat(j)+ilat*deps, alpha, beta, ipanel_tmp(count), .TRUE.)
+          END DO
+        end do
+      end do
+
+      !
+      ! remove duplicates in ipanel_tmp
+      !
+      CALL remove_duplicates_integer(count,ipanel_tmp(1:count),&
+           k,ipanel_array(1:count))
+      !
+      !---------------------------------------------------
+      !
+      ! loop over panels with possible overlap areas
+      !
+      !---------------------------------------------------          
+      !
+      DO ip = 1,k
+        ipanel = ipanel_array(ip)
+        DO j=1,ncorner_this_cell
+          ii = ipanel
+          CALL CubedSphereABPFromRLL(lon(j), lat(j), alpha, beta, ii,.FALSE.)
+          IF (j==1) THEN
+            jx = CEILING((alpha + piq) / da)
+            jy = CEILING((beta  + piq) / da)
+          END IF
+          xcell(ncorner_this_cell+1-j) = TAN(alpha)
+          ycell(ncorner_this_cell+1-j) = TAN(beta)
+        END DO
+        xcell(0) = xcell(ncorner_this_cell)
+        ycell(0) = ycell(ncorner_this_cell)
+        xcell(ncorner_this_cell+1) = xcell(1)
+        ycell(ncorner_this_cell+1) = ycell(1)
+
+        jx = MAX(MIN(jx,ncube+1),0)
+        jy = MAX(MIN(jy,ncube+1),0)
+
+
+        CALL compute_weights_cell(xcell(0:ncorner_this_cell+1),ycell(0:ncorner_this_cell+1),&
+             jx,jy,nreconstruction,xgno,ygno,&
+             1, ncube+1, 1,ncube+1, tmp,&
+             ngauss,gauss_weights,abscissae,weights,weights_eul_index,jcollect,jmax_segments,&
+             ncube,0,ncorner_this_cell,ldbg,i)
+
+
+        IF (jcollect > jmax_segments) THEN
+          WRITE(*,*) "WARNING: jcollect > jmax_segments!", jcollect, jmax_segments
+        ENDIF
+
+        IF (jcollect <= 0) THEN
+          If (ldbg) WRITE(*,*) "WARNING: Skipping target", i, "with no overlap (jcollect = 0)"
+           CYCLE
+        ENDIF
+
+       IF (.NOT. ALLOCATED(weights_all) .OR. &
+           SIZE(weights_all,1) < jall + jcollect) THEN
+         CALL ensure_capacity(MAX(jcollect,1024), jall, nreconstruction, &
+                              weights_all, weights_eul_index_all, &
+                              weights_lgr_index_all)
+       END IF
+
+
+        weights_all(jall + 1 : jall + jcollect, :) = weights(1:jcollect,:)
+        weights_eul_index_all(jall + 1 : jall + jcollect, 1:2) = weights_eul_index(1:jcollect,:)
+        weights_eul_index_all(jall + 1 : jall + jcollect, 3) = ipanel
+        weights_lgr_index_all(jall + 1 : jall + jcollect) = i
+
+        jall = jall + jcollect
+
+      END DO
+    END DO
+
+    !====================================================================
+    !  ensure_capacity  – dynamically (re)allocates the three big weight
+    !  arrays so that at least  jall+extra‑1  rows are available.
+    !  Runs like res c5760 can't run without this
+    !  Handles the very first call where the arrays are unallocated.
+    ! Uses MOVE_ALLOC, so no manual DEALLOCATE is ever needed.
+    !====================================================================
+    CONTAINS
+
+    SUBROUTINE ensure_capacity(extra, jall, nreconstruction,             &
+                               weights_all, weights_eul_index_all,      &
+                               weights_lgr_index_all)
+      USE shr_kind_mod, only: r8 => shr_kind_r8, i8 => shr_kind_i8
+      IMPLICIT NONE
+    
+      ! Arguments
+      INTEGER(i8), INTENT(IN)    :: extra             
+      INTEGER(i8), INTENT(IN)    :: jall              
+      INTEGER, INTENT(IN)        :: nreconstruction   
+    
+      REAL(r8), ALLOCATABLE, INTENT(INOUT) :: weights_all(:,:)            
+      INTEGER , ALLOCATABLE, INTENT(INOUT) :: weights_eul_index_all(:,:)  
+      INTEGER , ALLOCATABLE, INTENT(INOUT) :: weights_lgr_index_all(:)    
+    
+      ! Local variables
+      INTEGER                    :: stat
+      INTEGER(i8)                :: newRows, oldRows, rowsToCopy
+    
+      REAL(r8), ALLOCATABLE      :: tmp_r(:,:)
+      INTEGER, ALLOCATABLE       :: tmp_i2(:,:), tmp_i1(:)
+    
+      ! Correct and consistent integer kind handling
+      IF (ALLOCATED(weights_all)) THEN
+        oldRows = SIZE(weights_all,1,KIND=i8)
+      ELSE
+        oldRows = 0_i8
+      END IF
+    
+      IF (ALLOCATED(weights_all)) THEN
+        newRows = MAX(oldRows*2_i8, jall + extra)
+      ELSE
+        newRows = MAX(1024_i8, jall + extra)
+      END IF
+    
+      ! Explicit print statement for debugging
+      WRITE(*,*) "ensure_capacity: oldRows=", oldRows, &
+                 " jall=", jall, " extra=", extra, " newRows=", newRows
+    
+      ! Resize weights_all safely
+      IF (ALLOCATED(weights_all)) CALL MOVE_ALLOC(weights_all, tmp_r)
+      ALLOCATE(weights_all(newRows, nreconstruction), STAT=stat)
+    
+      IF (jall > 0_i8 .AND. ALLOCATED(tmp_r)) THEN
+        rowsToCopy = MIN(jall, SIZE(tmp_r,1,KIND=i8))
+        weights_all(1:rowsToCopy,:) = tmp_r(1:rowsToCopy,:)
+      END IF
+    
+      ! Resize weights_eul_index_all safely
+      IF (ALLOCATED(weights_eul_index_all)) CALL MOVE_ALLOC(weights_eul_index_all, tmp_i2)
+      ALLOCATE(weights_eul_index_all(newRows, 3), STAT=stat)
+    
+      IF (jall > 0_i8 .AND. ALLOCATED(tmp_i2)) THEN
+        rowsToCopy = MIN(jall, SIZE(tmp_i2,1,KIND=i8))
+        weights_eul_index_all(1:rowsToCopy,:) = tmp_i2(1:rowsToCopy,:)
+      END IF
+    
+      ! Resize weights_lgr_index_all safely
+      IF (ALLOCATED(weights_lgr_index_all)) CALL MOVE_ALLOC(weights_lgr_index_all, tmp_i1)
+      ALLOCATE(weights_lgr_index_all(newRows), STAT=stat)
+    
+      IF (jall > 0_i8 .AND. ALLOCATED(tmp_i1)) THEN
+        rowsToCopy = MIN(jall, SIZE(tmp_i1,KIND=i8))
+        weights_lgr_index_all(1:rowsToCopy) = tmp_i1(1:rowsToCopy)
+      END IF
+    
+    END SUBROUTINE ensure_capacity
+
+  END SUBROUTINE overlap_weights
+
+END MODULE overlap_mod
 !
 program convterr
-  use shr_kind_mod, only: r8 => shr_kind_r8
+  use shr_kind_mod, only: r8 => shr_kind_r8,i8 => shr_kind_i8
   use smooth_topo_cube_sph
   use ridge_ana
   use shared_vars
   use reconstruct
   use f90getopt
+  USE overlap_mod
   
   implicit none
 #     include         <netcdf.inc>
@@ -29,7 +352,8 @@ program convterr
   logical :: ldbg=.false.
   real(r8):: wt
   integer :: ii,ip,jx,jy,jp,np,counti !counters,dimensions
-  integer :: jmax_segments=-1,jall,jall_anticipated !overlap segments
+  integer(kind=8) ::  jall_anticipated
+  integer(i8) :: jmax_segments = -1, jall
   integer, parameter :: ngauss = 3               !quadrature for line integrals
   
   integer                              :: ntarget, ncorner, nrank, nlon, nlat               !target grid dimensions
@@ -124,6 +448,9 @@ program convterr
 
   type(option_s):: opts(24)
   character :: getopt_return
+
+  integer :: seg_est
+  integer(kind=8) :: jall_anticipated_8
   !               
   !                     long name                   has     | short | specified    | required
   !                                                 argument| name  | command line | argument
@@ -156,7 +483,10 @@ program convterr
   write(*,*)'bmaa hello' 
   ! END longopts
   ! If no options were committed
-  if (command_argument_count() .eq. 0 ) call print_help
+  if (command_argument_count() == 0) then
+    call print_help
+    stop 0
+  endif
   !
   ! collect command line arguments in this string for netCDF meta data
   !
@@ -351,7 +681,7 @@ program convterr
   write(*,*) "jmax_segments                   = ",jmax_segments
 
   !*********************************************************
-  
+ 
   call  set_constants
   
   ! Read in target grid
@@ -359,6 +689,11 @@ program convterr
   if (.not.lstop_after_smoothing) then
     call read_target_grid(grid_descriptor_fname,lregional_refinement,ltarget_latlon,lpole,nlat,nlon,ntarget,ncorner,nrank,&
          target_corner_lon, target_corner_lat, target_center_lon, target_center_lat, target_area, target_rrfac)
+
+      ! after you decide lregional_refinement
+      if (lregional_refinement .and. .not. lwrite_rrfac_to_topo_file) then
+          lwrite_rrfac_to_topo_file = .TRUE.
+      end if
     if (.not.lregional_refinement.and.rrfac_max.ne.1) then
       write(*,*) "User has set rrfac_max =",rrfac_max
       write(*,*) "which turns on regional refinement, however, the refinementfactor is not on grid descriptor file"
@@ -548,11 +883,41 @@ program convterr
     endif
   end if
   
-  output_fname = TRIM(str_dir)//'/'//trim(output_grid)//'_'//trim(str_source)//trim(ofile)//'_'//date//'.nc'
+  !---------------------------------------------------------------
+  ! 1.  Ensure the output directory string is never blank.
+  !     (If the user omits --output_data_directory we default
+  !      to the current working directory.)
+  !---------------------------------------------------------------
+  IF (TRIM(str_dir) == '') str_dir = './'
+  
+  !---------------------------------------------------------------
+  ! 2.  Make sure the directory now exists.
+  !     ‘mkdir -p’ is harmless if it already exists.
+  !---------------------------------------------------------------
+  CALL system('mkdir -p ' // TRIM(str_dir))
+  
+  !---------------------------------------------------------------
+  ! 3.  Now build the complete NetCDF file name.
+  !---------------------------------------------------------------
+  output_fname = TRIM(str_dir)//'/'//TRIM(output_grid)//'_'//  &
+                 TRIM(str_source)//TRIM(ofile)//'_'//date//'.nc'
+  
+  !---------------------------------------------------------------
+  ! 4.  Final sanity check: if something is still wrong, fall back
+  !     to a simple name so NetCDF create never gets “.nc”.
+  !---------------------------------------------------------------
+  IF (TRIM(output_fname) == '.nc' .OR. TRIM(output_fname) == '') THEN
+     output_fname = TRIM(str_dir)//'/topography.nc'
+     WRITE(*,*) 'WARNING: output_fname blank; writing to ',  &
+                TRIM(output_fname)
+  END IF
+  !---------------------------------------------------------------
+
+
   write(*,*) "Writing topo file to ",output_fname
   !*********************************************************
   !
-  ! script for plotting
+  ! ncl script for plotting
   !
   !*********************************************************
   if (.not.lstop_after_smoothing) then
@@ -564,70 +929,75 @@ program convterr
   
   !+++ARH
   ! Compute overlap weights
-  !------------------------------------------------------------------------------------------------
-  
-  ! On entry to overlap_weights 'jall' is a generous guess at the number of cells in
-  ! in the 'exchange grid'
-  allocate( rrfac(ncube,ncube,6)  )
-  rrfac = 0.0
-  
-  if (.not.lstop_after_smoothing) then    
-    if (nrank == 1) then
-      da_min_ncube  = 4.0*pi/(6.0*DBLE(ncube*ncube))
-      da_min_target = MAXVAL(target_area)
-      if (da_min_target==0) then !bug with MPAS files
-        write(*,*) "ERROR: da_min_target =",da_min_target
-        stop
-      else
-        if (jmax_segments<0) then
-           write(*,*) "using dynamic estimate for jmax_segments " 
-           !++ jtb : Increased by 4x. Needed for c1440 FV3
-           !jmax_segments = 10 * ncorner*NINT(da_min_target/da_min_ncube)!phl - FAILS for MPAS ~3km
-           jmax_segments = 4 * ncorner*NINT(da_min_target/da_min_ncube)
-           jmax_segments = MIN( jmax_segments, 10000 )
-        else
-           write(*,*) "jmax_segments set by user = ",jmax_segments
-        end if
-      end if
-      write(*,*) "ncorner, da_min_target, da_min_ncube =", ncorner, da_min_target, da_min_ncube
-      write(*,*) "jmax_segments",jmax_segments,da_min_target,da_min_ncube
-    else
-      if (jmax_segments<0) then
-         jmax_segments = 100000   !can be tweaked
-      else
-         write(*,*) "jmax_segments set by user = ",jmax_segments
-      end if
-    end if
-    if (real(ntarget)*real(jmax_segments)>huge(real(jall_anticipated))) then
-      jall_anticipated = 1080000000 !huge(jmax_segments) !anticipated number of weights (can be tweaked)
-      write(*,*) "truncating jall_anticipated to ",jall_anticipated
-    else
-      jall_anticipated = ntarget*jmax_segments !anticipated number of weights (can be tweaked)
-    end if
-    if (jall_anticipated<0) then
-      write(*,*) "anticipated number of overlaps likely not representable: jall_anticipated=", jall_anticipated
-      jall_anticipated = 1080000000
-      write(*,*) "setting to large value = ",jall_anticipated
-    else
-      write(*,*) "anticipated number of overlaps jall_anticipated=", jall_anticipated
-    end if
-    
+!------------------------------------------------------------------------------------------------
+    allocate(rrfac(ncube,ncube,6))
+    rrfac = 0.0_r8
 
-    
-    nreconstruction = 1
-    allocate (weights_all(jall_anticipated,nreconstruction),stat=alloc_error )
-    allocate (weights_eul_index_all(jall_anticipated,3),stat=alloc_error )
-    allocate (weights_lgr_index_all(jall_anticipated),stat=alloc_error )
-    jall=jall_anticipated
-    
-    if (.not.lstop_after_smoothing) then
-      write(*,*) "Compute overlap weights: "
-      CALL overlap_weights(weights_lgr_index_all,weights_eul_index_all,weights_all,&
-           jall,ncube,ngauss,ntarget,ncorner,jmax_segments,target_corner_lon,target_corner_lat,nreconstruction,ldbg)
-    end if
-    deallocate(target_corner_lon,target_corner_lat)
-  end if
-  ! On exit from overlap_weights 'jall' is the correct number of cells in the exchange grid. 
+   if (.not.lstop_after_smoothing) then
+     if (nrank == 1) then
+       da_min_ncube  = 4.0 * pi / (6.0 * DBLE(ncube * ncube))
+       da_min_target = MAXVAL(target_area)
+   
+       if (da_min_target <= 0.0_r8) then
+         write(*,*) "WARNING: invalid da_min_target =", da_min_target, " — using fallback jmax_segments = 10000"
+         jmax_segments = 10000
+       else
+         seg_est = 4 * ncorner * NINT(MAX(1.0e-12_r8, da_min_target / da_min_ncube))
+         if (seg_est < 1000) then
+           write(*,*) "WARNING: very small jmax_segments estimated =", seg_est
+           jmax_segments = 10000
+         else
+           jmax_segments = MIN(50000, seg_est)
+         end if
+       end if
+   
+       write(*,*) "ncorner, da_min_target, da_min_ncube =", ncorner, da_min_target, da_min_ncube
+       write(*,*) "jmax_segments =", jmax_segments, da_min_target, da_min_ncube
+   
+     else
+       if (jmax_segments < 0) then
+         seg_est = 4 * ncorner * NINT(MAX(1.0e-12_r8, da_min_target / da_min_ncube))
+         if (da_min_target <= 0.0_r8 .or. seg_est < 1000) then
+           write(*,*) "WARNING: invalid or too small da_min_target =", da_min_target
+           jmax_segments = 10000
+         else
+           jmax_segments = MIN(50000, seg_est)
+         end if
+         write(*,*) "FINAL jmax_segments =", jmax_segments
+       else
+         write(*,*) "jmax_segments set by user =", jmax_segments
+       end if
+     end if
+   
+     jall_anticipated_8 = INT(ntarget,8) * INT(jmax_segments,8) * 3_8
+     IF (jall_anticipated_8 > HUGE(jall_anticipated) .or. &
+         REAL(ntarget, r8) * REAL(jmax_segments, r8) > huge(1.0_r8) / 3.0) THEN
+       jall_anticipated = 1080000000
+       write(*,*) "WARNING: truncating jall_anticipated to fallback value =", jall_anticipated
+     ELSE
+       jall_anticipated = jall_anticipated_8
+     END IF
+   
+     IF (jall_anticipated <= 0) THEN
+       WRITE(*,*) "WARNING: jall_anticipated <= 0! Forcing fallback value."
+       jall_anticipated = MAX(1, ntarget * 3)
+     END IF
+   
+     nreconstruction = 1
+     jall            = 0_8          ! start empty – will grow on demand
+   
+     CALL overlap_weights(weights_lgr_index_all, weights_eul_index_all, weights_all, &
+          jall, ncube, ngauss, ntarget, ncorner, jmax_segments, target_corner_lon, target_corner_lat, &
+          nreconstruction, ldbg)
+   
+     if (SIZE(weights_all, 1) == 0) then
+       write(*,*) "ERROR: weights_all size is zero after overlap_weights — check INTENT() declarations."
+       stop
+     endif
+     write(*,*) "DEBUG: Finished overlap_weights subroutine call"   
+
+     deallocate(target_corner_lon,target_corner_lat)
+   end if
   !------------------------------------------------------------------------------------------------
   
   ! Set-up regional refinement control.
@@ -641,21 +1011,38 @@ program convterr
   if (lregional_refinement) then
     !--- remap rrfac to cube
     !-----------------------------------------------------------------
+    !Setting the whole 3-D array to zero first guarantees a clean slate; 
+    !every element is then filled by the mapping loop immediately below.
+     rrfac = 0.0_r8
+
+    write(*,*) 'Entering rrfac loop, jall =', jall
     do counti=1,jall
-      i    = weights_lgr_index_all(counti)!!
-      !
+
+        if (MOD(counti, 100000) == 0) then
+            write(*,*) 'DEBUG: rrfac loop progress:', counti, '/', jall
+        end if
+
+      i   = weights_lgr_index_all(counti)
       ix  = weights_eul_index_all(counti,1)
       iy  = weights_eul_index_all(counti,2)
       ip  = weights_eul_index_all(counti,3)
-      !
+
+      !–– Skip any row whose indices are out of bounds
+      IF (ix < 1 .OR. ix > ncube .OR. iy < 1 .OR. iy > ncube .OR. &
+          ip < 1 .OR. ip > 6)                 CYCLE
+      IF (i  < 1 .OR. i  > SIZE(target_rrfac)) CYCLE
+     !
       ! convert to 1D indexing of cubed-sphere
       !
-      ii = (ip-1)*ncube*ncube+(iy-1)*ncube+ix!
-      !
+      ii = (ip-1)*ncube*ncube+(iy-1)*ncube+ix  ! flat index (not used further here)
+      !  Overlap weight for this source → target pair
       wt = weights_all(counti,1)
       !
+      ! Add weighted contribution.  Divide by cell area (dA) so the
+      ! stored value is the **mean** refinement factor for the cell
       rrfac(ix,iy,ip) = rrfac(ix,iy,ip) + wt*(target_rrfac(i))/dA(ix,iy)
     end do
+    write(*,*) 'DEBUG: completed rrfac loop'
   else
     write(*,*) " NO refinement: RRFAC = 1. everywhere "
     rrfac = 1.0_r8
@@ -725,23 +1112,37 @@ program convterr
   write(*,*) " Topo volume BEFORE smoother = ",volterr/(6*sum(da))
   write(*,*) " Topo volume  AFTER smoother = ",volterr_sm/(6*sum(da))
   write(*,*) "            Difference       = ",(volterr - volterr_sm)/(6*sum(da))
-  
-  if (ldistance_weighted_smoother) then
-    terr_sm = (volterr/volterr_sm)*terr_sm! should we do this?
+ 
+!------------------------------------------------------------
+! Optional global-volume correction after smoothing
+!
+!  Smoothing diffuses peaks more than it fills valleys, so the
+!  integrated terrain volume (and mean PHIS) usually drops a
+!  bit.  The line below rescales the smoothed field so that its
+!  volume matches the original.  Enable it if your downstream
+!  model needs strict preservation of global mean height.
+!
+!  terr_sm = (volterr / volterr_sm) * terr_sm
+!
+!------------------------------------------------------------  
+
+  if (ldistance_weighted_smoother .or. lregional_refinement) then
+    terr_sm = (volterr/volterr_sm)*terr_sm
   end if
-  volterr_sm=0.
-  do np=1,6 
+
+   volterr_sm=0.
+   do np=1,6 
     volterr_sm =  volterr_sm + sum( terr_sm(:,:,np) * da )
-    end do
-    
-    write(*,*) " Topo volume  AFTER smoother AND fixer = ",volterr_sm/(6*sum(da))
+   end do
+   write(*,*) " Topo volume  AFTER smoother AND fixer = ",volterr_sm/(6*sum(da))
     
     
     if(lfind_ridges) then
       nsw = nwindow_halfwidth
       nhalo=2*nsw
       
-      call find_local_maxes ( terr_dev, ncube, nhalo, nsw, iopt_ridge_seed )
+      call find_local_maxes ( terr_dev, ncube, nhalo, nsw, iopt_ridge_seed, &
+                              lregional_refinement, rrfac )
 
 
       call find_ridges ( terr_dev, terr, ncube, nhalo, nsw,&
@@ -921,11 +1322,15 @@ program convterr
     sgh_uf_target=0.0
     do counti=1,jall
       
-      i    = weights_lgr_index_all(counti)!!
-      !
+      i   = weights_lgr_index_all(counti)
       ix  = weights_eul_index_all(counti,1)
       iy  = weights_eul_index_all(counti,2)
       ip  = weights_eul_index_all(counti,3)
+
+        !–– Skip any row whose indices are out of bounds
+        IF (ix < 1 .OR. ix > ncube .OR. iy < 1 .OR. iy > ncube .OR. &
+            ip < 1 .OR. ip > 6)                 CYCLE
+        IF (i  < 1 .OR. i  > ntarget)           CYCLE
       !
       ! convert to 1D indexing of cubed-sphere
       !
@@ -955,7 +1360,21 @@ program convterr
       allocate( nodesC( ncube*ncube*6 ), cwghtC( ncube*ncube*6 ) )
       allocate( itrgtC( ncube*ncube*6 )  )
   
- 
+    !-----------------------------------------------------------------
+    ! Allocate rrfac only once – needed by either distance-weighted
+    ! smoother OR regional-refinement.  Safe for both cases.
+    !-----------------------------------------------------------------
+    IF (ldistance_weighted_smoother .OR. lregional_refinement) THEN
+       IF (.NOT. ALLOCATED(rrfac)) THEN
+          allocate(rrfac(ncube,ncube,6), stat=alloc_error)
+          IF (alloc_error /= 0) STOP 'alloc rrfac'
+          rrfac = 1.0_r8     ! 1 ⇒ “no refinement” default
+       END IF
+    END IF      
+
+      ! (If a later routine fills real refinement factors, only those
+      !  elements will be overwritten; everywhere else stays at 1.)
+      !-------------------------------------------------------- 
       call remapridge2cube( ncube,nhalo,nsw, &
            ncube_sph_smooth_coarse,ncube_sph_smooth_fine,lzero_negative_peaks, &
            ldevelopment_diags,lregional_refinement,  &
@@ -972,7 +1391,9 @@ program convterr
            output_grid, ldevelopment_diags,&
            terr_dev, uniqiC, uniqwC, anisoC, &
            anglxC,mxdisC,hwdthC,clngtC, &
-           riseqC,fallqC,mxvrxC,mxvryC,nodesC,cwghtC, itrgtC  )
+           riseqC,fallqC,mxvrxC,mxvryC,nodesC,cwghtC, itrgtC, &
+           lregional_refinement=lregional_refinement,   &
+           rr_factor      =rrfac   )
 
       if (lridgetiles) then 
       call remapridge2tiles ( ntarget,ncube,jall,nreconstruction,     &
@@ -980,7 +1401,9 @@ program convterr
            weights_eul_index_all(1:jall,:), &
            weights_lgr_index_all(1:jall),  &
            weights_all(1:jall,:), &
-           uniqiC,uniqwC,itrgtC,wedgoC )
+           uniqiC,uniqwC,itrgtC,wedgoC, &
+           lregional_refinement=lregional_refinement,   &
+           rr_factor      =rrfac   )
       end if      
 
       deallocate( uniqiC,uniqwC,anisoC,anglxC,mxdisC,hwdthC,clngtC, &
@@ -993,11 +1416,17 @@ program convterr
       rrfac_target = 0.0_r8
       do counti=1,jall
         
-        i    = weights_lgr_index_all(counti)!!
-        !
+        i   = weights_lgr_index_all(counti)
         ix  = weights_eul_index_all(counti,1)
         iy  = weights_eul_index_all(counti,2)
         ip  = weights_eul_index_all(counti,3)
+
+      !–– Skip any row whose indices are out of bounds  ------------------
+      IF (ix < 1 .OR. ix > ncube .OR. iy < 1 .OR. iy > ncube .OR. &
+          ip < 1 .OR. ip > 6)                CYCLE
+      IF (i  < 1 .OR. i  > ntarget)          CYCLE
+      !------------------------------------------------------------------
+
         !
         ! convert to 1D indexing of cubed-sphere
         !
@@ -1073,17 +1502,12 @@ program convterr
     if (lphis_gll) then
       call read_target_grid(grid_descriptor_fname_gll,lregional_refinement,ltarget_latlon,lpole,nlat,nlon,ntarget,ncorner,nrank,&
            target_corner_lon, target_corner_lat, target_center_lon, target_center_lat, target_area, target_rrfac)
+
       allocate (terr_target(ntarget))
       if (linterp_phis) then
         CALL bilinear_interp(ncube,ntarget,target_center_lon,target_center_lat,terr_sm(1:ncube,1:ncube,:),terr_target)
       else
-        allocate (weights_all(jall_anticipated,nreconstruction),stat=alloc_error )
-        allocate (weights_eul_index_all(jall_anticipated,3),stat=alloc_error )
-        allocate (weights_lgr_index_all(jall_anticipated),stat=alloc_error )
-        weights_all = 0.0_r8
-        weights_eul_index_all = 0
-        weights_lgr_index_all = 0
-        jall=jall_anticipated
+        jall = 0   ! dynamic fill again for GLL grid
         
         write(*,*) "Compute overlap weights for GLL grid: "
         CALL overlap_weights(weights_lgr_index_all,weights_eul_index_all,weights_all,&
@@ -1102,11 +1526,19 @@ program convterr
         
         terr_target=0.0
         do counti=1,jall        
-          i    = weights_lgr_index_all(counti)!!
-          !
+          i    = weights_lgr_index_all(counti)
           ix  = weights_eul_index_all(counti,1)
           iy  = weights_eul_index_all(counti,2)
           ip  = weights_eul_index_all(counti,3)
+
+        ! >>> Bounds check <<<
+         if (ix < 1 .or. ix > ncube .or. iy < 1 .or. iy > ncube .or. &
+            ip < 1 .or. ip > 6) then
+            !if (ldbg_rr) write(*,*) 'ERROR: Invalid indices in TERRAIN map: ', counti, &
+           !           ' ix=', ix, ' iy=', iy, ' ip=', ip
+           cycle  ! 'cycle' to skip
+         end if
+          
           !
           ! convert to 1D indexing of cubed-sphere
           !
@@ -1116,63 +1548,63 @@ program convterr
           
           terr_target (i) = terr_target (i) + wt*(terr_sm(ix,iy,ip))/area_target(i) 
         end do
-        DEALLOCATE(weights_all,weights_eul_index_all)
+        
+          !--- Clean up dynamic memory used in mapping ---!
+          IF (ALLOCATED(weights_all))             DEALLOCATE(weights_all)
+          IF (ALLOCATED(weights_eul_index_all))   DEALLOCATE(weights_eul_index_all)
+          IF (ALLOCATED(weights_lgr_index_all))   DEALLOCATE(weights_lgr_index_all)
+          IF (ALLOCATED(rrfac))                   DEALLOCATE(rrfac)
+
       end if
       CALL wrtncdf_unstructured_append_phis(ntarget,terr_target, &
            target_center_lon,target_center_lat,output_fname)
     end if
     end program convterr
-    
-  subroutine print_help
-    write (6,*) "THIS NEEDS TO BE UPDATED"
-    write (6,*) "Usage: cube_to_target [options] ..."
-    write (6,*) "Options:"
-    write (6,*) " "
-    write (6,*) "    STANDARD OPTIONS"
-    write (6,*) " "
-    write (6,*) "-u, --name_email_of_creator=<string> [required] -> name and Email address of creator"
-    write (6,*) "-g, --grid_descriptor_file=<string>  [required] -> ESMF or SCRIP compliant grid descriptor file"
-    write (6,*) "-i, --intermediate_cs_name=<string>  [required] -> intermediate cubed-sphere topo file (usually ncube3000)"
-    write (6,*) "-o, --output_grid=<string>           [required] -> identifier for output grid (e.g. ne30np4, f09x1.25, ..)"    
-    write (6,*) "-c, --smoothing_scale=<real> (in km)            -> standard 'climate' smoothing is -c=100 for 1 degree"
-    write (6,*) "-q, --output_data_directory=<string>            -> data output directory (default is output)"
-    write (6,*) " "
-    write (6,*) "    REGIONAL REFINEMENT OPTIONS"
-    write (6,*) " "
-    write (6,*) "-y, --rrfac_max=<int>   [required for var res]  -> maximum refinement level"
-    write (6,*) "-v, --rrfac_manipulation                        -> enable manipulation of rrfac (used for spectral-element grids)"
-    write (6,*) " "
-    write (6,*) "    DISTANCE WEIGHTED SMOOTHER OPTIONS (DEFAULT IS LAPLACIAN)"
-    write (6,*) " "
-    write (6,*) "-b, --distance_weighted_smoother                -> enable distance weighted smoother"
-    write (6,*) "-p, --use_prefilter                             -> -b smoother option"
-    write (6,*) "-f, --fine_radius=<int>                         -> "
-    write (6,*) " "
-    write (6,*) "   LAPLACIAN SMOOTHER OPTIONS"
-    write (6,*) " "
-    write (6,*) "-m, --smoothing_over_ocean                      -> do not restrict smoother to only smooth over land"
-    write (6,*) "-l, --smooth_phis_numcycle                      -> number of subcycles for Laplacian smoother (for stability)"
-    write (6,*) " "
-    write (6,*) "   MISCELLANEOUS OPTIONS"
-    write (6,*) " "
-    write (6,*) "-r, --no_ridges                                 -> do not compute sub-grid-scale ridges"
-    write (6,*) "-x, --stop_after_smooth                         -> stop after smoothing"
-    write (6,*) "-1, --ridge2tiles                               -> ??? "
-    write (6,*) "-z, --development_diags                         -> enable development diagnostics (for developers)"
-    write (6,*) " "
-    write (6,*) "-t, --smooth_topo_file=<string>                 -> use pre-compured smooth topo file"
-    write (6,*) "-d, --write_rrfac_to_topo_file                  -> write rrfac to final topo file (usually for debugging)"
-    write (6,*) " "
-    write (6,*) "-n, --source_data_identifier=<string>           -> source topo data identifier"
-    write (6,*) "                                                   (default gmted2010_modis_bedmachine)"
-    write (6,*) " "
-    write (6,*) "-a, --grid_descriptor_file_gll=<string>         -> grid descriptor file for dual grid configurations"
-    write (6,*) "-s, --interpolate_phis                          -> bilinear interpolate PHIS to target grid (instead of remapping)"
-    write (6,*) "-j, --jmax_segments                             -> max number of overlap segments"
 
+   subroutine print_help
+     ! Updated help text May 2025 to match actual flags in cube_to_target.x
+     write(6,*) "Usage: cube_to_target [options] ..."
+     write(6,*) "Options:"
+     write(6,*) ""
+     write(6,*) "  STANDARD OPTIONS"
+     write(6,*) ""
+     write(6,*) "-u, --name_email_of_creator=<string>       Name and email of creator (required)"
+     write(6,*) "-g, --grid_descriptor_file=<string>        ESMF or SCRIP grid descriptor (required)"
+     write(6,*) "-i, --intermediate_cs_name=<string>        Intermediate cubed-sphere topo file (required)"
+     write(6,*) "-o, --output_grid=<string>                 Identifier for output grid (e.g. PE270x1620-CF)"
+     write(6,*) "-q, --output_data_directory=<string>       Data output directory (default 'output')"
+     write(6,*) "-c, --smoothing_scale=<real>               Smoothing scale in km. Standard 'climate' smoothing is -c=100 for 1 degree"
+     write(6,*) "-f, --fine_radius=<int>                    Fine radius for distance-weighted smoother"
+     write(6,*) ""
+     write(6,*) "  REGIONAL REFINEMENT OPTIONS"
+     write(6,*) ""
+     write(6,*) "-y, --rrfac_max=<int>                      Maximum refinement factor (coarse/fine ratio; required if >1)"
+     write(6,*) "-d, --write_rrfac_to_topo_file             Write out the regional refinement factors file"
+     write(6,*) "-x, --stop_after_smooth                    Stop after smoothing (only writes rrfac)"
+     write(6,*) "-v, --rrfac_manipulation                   Enable manipulation of refinement factors (used for spectral-element grids)"
+     write(6,*) ""
+     write(6,*) "  DISTANCE WEIGHTED SMOOTHER OPTIONS"
+     write(6,*) ""
+     write(6,*) "-b, --distance_weighted_smoother           Enable distance-weighted smoother"
+     write(6,*) "-p, --use_prefilter                        Pre-filter before smoothing"
+     write(6,*) ""
+     write(6,*) "  LAPLACIAN SMOOTHER OPTIONS"
+     write(6,*) ""
+     write(6,*) "-m, --smoothing_over_ocean                 Smooth over ocean as well as land"
+     write(6,*) "-l, --smooth_phis_numcycle=<int>           Subcycles for Laplacian smoother"
+     write(6,*) ""
+     write(6,*) "  MISCELLANEOUS OPTIONS"
+     write(6,*) ""
+     write(6,*) "-r, --no_ridges                            Disable ridge detection"
+     write(6,*) "-1, --ridge2tiles                          Convert ridges to tile mask"
+     write(6,*) "-z, --development_diags                    Enable development diagnostics"
+     write(6,*) "-t, --smooth_topo_file=<string>            Use pre-computed smooth topo file"
+     write(6,*) "-n, --source_data_identifier=<string>      Source topo identifier (default 'gmted_intel')"
+     write(6,*) "-a, --grid_descriptor_file_gll=<string>    Grid descriptor for dual-grid configurations"
+     write(6,*) "-s, --interpolate_phis                     Bilinear interpolate PHIS to target grid"
+     write(6,*) "-j, --jmax_segments=<int>                  Override maximum overlap segments"
+   end subroutine print_help
 
-    stop
-  end subroutine print_help
   !
   !
   !
@@ -1557,6 +1989,7 @@ program convterr
     ! End define mode for output file
     !
     status = nf_enddef (foutid)
+    WRITE(*,*) 'DEBUG nf_enddef status = 3', status
     if (status .ne. NF_NOERR) call handle_err(status)
     !
     ! Write variable for output
@@ -1774,7 +2207,8 @@ program convterr
     ! End define mode for output file
     !
     status = nf_enddef (foutid)
-    call handle_err(1) !bmaa
+    !call handle_err(1) !bmaa
+    WRITE(*,*) 'DEBUG nf_enddef status =', status
     if (status .ne. NF_NOERR) call handle_err(status)
     !
     ! Write variable for output
@@ -2205,6 +2639,7 @@ program convterr
     ! End define mode for output file
     !
     status = nf_enddef (foutid)
+    WRITE(*,*) 'DEBUG nf_enddef status 2=', status
     if (status .ne. NF_NOERR) call handle_err(status)
     !
     ! Write variable for output
@@ -2438,234 +2873,6 @@ program convterr
     
   end subroutine handle_err
   
-  
-  !*******************************************************************************
-  !  At this point mapping arrays are calculated
-  !
-  !      weights_lgr_index_all: dimension(JALL). Index of target grid cell that contains
-  !                             current exchange grid cell
-  ! 
-  !      weights_eul_index_all: dimension(JALL,3). 3 indices of cubed-sphere grid cell that 
-  !                             contains current exchange grid cell:
-  !
-  !                                weights_eul_index_all(:,1) = x-index
-  !                                weights_eul_index_all(:,2) = y-index
-  !                                weights_eul_index_all(:,3) = panel/face number 1-6
-  !
-  !                             These are then converted to one-dimensional indices 
-  !                             for cubed sphere variables terr(n), ... etc. 
-  !
-  !      weights_all:           dimension(JALL,nreconstrunction). Spherical area of
-  !                             exchange grid cell (steradians)
-  !
-  !********************************************************************************
-  
-  
-  SUBROUTINE overlap_weights(weights_lgr_index_all,weights_eul_index_all,weights_all,&
-       jall,ncube,ngauss,ntarget,ncorner,jmax_segments,target_corner_lon,target_corner_lat,nreconstruction,ldbg)
-    use shr_kind_mod, only: r8 => shr_kind_r8
-    use remap
-    use shared_vars, only: progress_bar
-    IMPLICIT NONE
-    
-    
-    INTEGER,                                     INTENT(INOUT):: jall !anticipated number of weights
-    INTEGER,                                     INTENT(IN)   :: ncube, ngauss, ntarget, jmax_segments, ncorner, nreconstruction
-    
-    INTEGER, DIMENSION(jall,3),                  INTENT(OUT)  :: weights_eul_index_all
-    REAL(R8), DIMENSION(jall,nreconstruction)  , INTENT(OUT)  :: weights_all
-    INTEGER, DIMENSION(jall)  ,                  INTENT(OUT)  :: weights_lgr_index_all
-    
-    REAL(R8), DIMENSION(ncorner,ntarget),        INTENT(INOUT):: target_corner_lon, target_corner_lat
-    LOGICAL,                                     INTENT(IN)   :: ldbg
-    
-    INTEGER,  DIMENSION(9*(ncorner+1)) :: ipanel_tmp,ipanel_array
-    REAL(R8), DIMENSION(ncorner)  :: lat, lon
-    REAL(R8), DIMENSION(0:ncube+2):: xgno, ygno
-    REAL(R8), DIMENSION(0:ncorner+1) :: xcell, ycell
-    
-    REAL(R8), DIMENSION(ngauss) :: gauss_weights, abscissae
-    
-    REAL(R8) :: da, tmp, alpha, beta
-    REAL    (r8):: pi,piq,pih
-    INTEGER :: i, j,ncorner_this_cell,k,ip,ipanel,ii,jx,jy,jcollect
-    integer :: alloc_error, ilon,ilat
-    
-    REAL    (r8) :: rad2deg
-    REAL    (r8) :: deps
-    
-    real(r8), allocatable, dimension(:,:) :: weights
-    integer , allocatable, dimension(:,:) :: weights_eul_index
-    
-    INTEGER :: jall_anticipated, count
-    
-    pi = 4.D0*DATAN(1.D0)
-    piq = pi/4.D0
-    pih = pi*0.5D0
-    rad2deg = 180.D0/pi
-    
-    deps = 10.0D0*pi/180.0_r8
-    
-    jall_anticipated = jall
-    
-    ipanel_array = -99
-    !
-    da = pih/DBLE(ncube)
-    xgno(0) = -bignum
-    DO i=1,ncube+1
-      xgno(i) = TAN(-piq+(i-1)*da)
-    END DO
-    xgno(ncube+2) = bignum
-    ygno = xgno
-    
-    CALL glwp(ngauss,gauss_weights,abscissae)
-    
-    
-    allocate (weights(jmax_segments,nreconstruction),stat=alloc_error )
-    allocate (weights_eul_index(jmax_segments,2),stat=alloc_error )
-    
-    tmp = 0.0
-    jall = 1
-    DO i=1,ntarget
-      if (MOD(i,10)==0)call progress_bar("# ", i, DBLE(100*i)/DBLE(ntarget))
-      !
-      !---------------------------------------------------          
-      !
-      ! determine how many vertices the cell has
-      !
-      !---------------------------------------------------
-      !
-      CALL remove_duplicates_latlon(ncorner,target_corner_lon(:,i),target_corner_lat(:,i),&
-           ncorner_this_cell,lon,lat,1.0E-10)
-      
-      IF (ldbg) THEN
-        WRITE(*,*) "number of vertices ",ncorner_this_cell
-        WRITE(*,*) "vertices locations lon,",lon(1:ncorner_this_cell)*rad2deg
-        WRITE(*,*) "vertices locations lat,",lat(1:ncorner_this_cell)*rad2deg
-        DO j=1,ncorner_this_cell
-          WRITE(*,*) lon(j)*rad2deg, lat(j)*rad2deg
-        END DO
-        WRITE(*,*) "  "
-      END IF
-      !
-      !---------------------------------------------------
-      !
-      ! determine how many and which panels the cell spans
-      !
-      !---------------------------------------------------          
-      !
-#ifdef old    
-      DO j=1,ncorner_this_cell
-        CALL CubedSphereABPFromRLL(lon(j), lat(j), alpha, beta, ipanel_tmp(j), .TRUE.)
-        IF (ldbg) WRITE(*,*) "ipanel for corner ",j," is ",ipanel_tmp(j)
-      END DO
-      ipanel_tmp(ncorner_this_cell+1) = ipanel_tmp(1)
-      ! make sure to include possible overlap areas not on the face the vertices are located
-      IF (MINVAL(lat(1:ncorner_this_cell))<-pi/6.0) THEN
-        ! include South-pole panel in search
-        ipanel_tmp(ncorner_this_cell+1) = 5
-        IF (ldbg) WRITE(*,*)  "add panel 5 to search"
-      END IF
-      IF (MAXVAL(lat(1:ncorner_this_cell))>pi/6.0) THEN
-        ! include North-pole panel in search
-        ipanel_tmp(ncorner_this_cell+1) = 6
-        IF (ldbg) WRITE(*,*)  "add panel 6 to search"
-      END IF
-      CALL remove_duplicates_integer(ncorner_this_cell+1,ipanel_tmp(1:ncorner_this_cell+1),&
-           k,ipanel_array(1:ncorner_this_cell+1))
-#endif
-      !
-      ! make sure to include possible overlap areas not on the face the vertices are located
-      ! For example, a cell could be on panel 3 and 5 but have overlap area on panel 2
-      count = 0
-      do ilat=-1,1
-        do ilon=-1,1
-          DO j=1,ncorner_this_cell
-            count=count+1
-            CALL CubedSphereABPFromRLL(lon(j)+ilon*deps, lat(j)+ilat*deps, alpha, beta, ipanel_tmp(count), .TRUE.)
-          END DO
-        end do
-      end do
-      
-      !
-      ! remove duplicates in ipanel_tmp
-      !
-      CALL remove_duplicates_integer(count,ipanel_tmp(1:count),&
-           k,ipanel_array(1:count))
-      !
-      !---------------------------------------------------
-      !
-      ! loop over panels with possible overlap areas
-      !
-      !---------------------------------------------------          
-      !
-      DO ip = 1,k
-        ipanel = ipanel_array(ip)
-        DO j=1,ncorner_this_cell
-          ii = ipanel
-          CALL CubedSphereABPFromRLL(lon(j), lat(j), alpha, beta, ii,.FALSE.)            
-          IF (j==1) THEN
-            jx = CEILING((alpha + piq) / da)
-            jy = CEILING((beta  + piq) / da)
-          END IF
-          xcell(ncorner_this_cell+1-j) = TAN(alpha)
-          ycell(ncorner_this_cell+1-j) = TAN(beta)
-        END DO
-        xcell(0) = xcell(ncorner_this_cell)
-        ycell(0) = ycell(ncorner_this_cell)
-        xcell(ncorner_this_cell+1) = xcell(1)
-        ycell(ncorner_this_cell+1) = ycell(1)
-        
-        jx = MAX(MIN(jx,ncube+1),0)
-        jy = MAX(MIN(jy,ncube+1),0)
-        
-        CALL compute_weights_cell(xcell(0:ncorner_this_cell+1),ycell(0:ncorner_this_cell+1),&
-             jx,jy,nreconstruction,xgno,ygno,&
-             1, ncube+1, 1,ncube+1, tmp,&
-             ngauss,gauss_weights,abscissae,weights,weights_eul_index,jcollect,jmax_segments,&
-             ncube,0,ncorner_this_cell,ldbg,i)
-        
-        weights_all(jall:jall+jcollect-1,1:nreconstruction)  = weights(1:jcollect,1:nreconstruction)
-        
-        
-        !weights_eul_index_all(jall:jall+jcollect-1,1:2) = weights_eul_index(1:jcollect,:)
-        weights_eul_index_all(jall:jall+jcollect-1,  1) = weights_eul_index(1:jcollect,1)
-        weights_eul_index_all(jall:jall+jcollect-1,  2) = weights_eul_index(1:jcollect,2)
-        weights_eul_index_all(jall:jall+jcollect-1,  3) = ipanel
-        weights_lgr_index_all(jall:jall+jcollect-1    ) = i
-        
-        jall = jall+jcollect
-        IF (jall>jall_anticipated) THEN
-          WRITE(*,*) "more weights than anticipated"
-          WRITE(*,*) "increase jall"
-          STOP
-        END IF
-        IF (ldbg) WRITE(*,*) "jcollect",jcollect
-      END DO
-    END DO
-    jall = jall-1
-    WRITE(*,*) "sum of all weights divided by surface area of sphere  =",tmp/(4.0*pi)
-    WRITE(*,*) "actual number of weights",jall
-    WRITE(*,*) "anticipated number of weights",jall_anticipated
-    IF (jall>jall_anticipated) THEN
-      WRITE(*,*) "anticipated number of weights < actual number of weights"
-      WRITE(*,*) "increase jall!"
-      STOP
-    END IF
-    !  WRITE(*,*) MINVAL(weights_all(1:jall,1)),MAXVAL(weights_all(1:jall,1))
-    
-    IF (ABS(tmp/(4.0*pi))-1.0>0.001) THEN
-      WRITE(*,*) "sum of all weights does not match the surface area of the sphere"
-      WRITE(*,*) "sum of all weights is : ",tmp
-      WRITE(*,*) "surface area of sphere: ",4.0*pi
-      STOP
-    END IF
-    
-    
-    
-    
-  END SUBROUTINE overlap_weights
-  
   SUBROUTINE bilinear_interp(ncube,ntarget,target_center_lon,target_center_lat,terr_cube,terr_target)
     use shr_kind_mod, only: r8 => shr_kind_r8
     use shared_vars, only: progress_bar
@@ -2741,7 +2948,13 @@ program convterr
     REAL    (R8) :: xx, yy, zz, pm
     REAL    (R8) :: sx, sy, sz
     INTEGER  :: ix, iy, iz
+
+    IF (ISNAN(lon) .OR. ISNAN(lat)) THEN
+      WRITE(*,*) 'ERROR: NaN detected in CubedSphereABPFromRLL input: lon=', lon, ' lat=', lat
+      STOP
+    ENDIF
     
+
     ! Translate to (x,y,z) space
     xx = COS(lon-rotate_cube) * COS(lat)
     yy = SIN(lon-rotate_cube) * COS(lat)
@@ -2818,7 +3031,7 @@ program convterr
       ! Use panel information to calculate (alpha, beta) coords
       alpha = ATAN(sx / sz)
       beta = ATAN(sy / sz)
-      
+
     END SUBROUTINE CubedSphereABPFromRLL
     
         !------------------------------------------------------------------------------

--- a/cube_to_target/kdtree_mod.F90
+++ b/cube_to_target/kdtree_mod.F90
@@ -1,0 +1,259 @@
+module kdtree_mod
+    implicit none
+    
+    type :: kdtree_node
+        integer :: point_idx
+        real(8) :: coords(2)  ! lon, lat
+        type(kdtree_node), pointer :: left => null()
+        type(kdtree_node), pointer :: right => null()
+        integer :: split_dim  ! 1 for lon, 2 for lat
+    end type kdtree_node
+    
+    type :: kdtree
+        type(kdtree_node), pointer :: root => null()
+        integer :: num_points
+        real(8), allocatable :: points(:,:)  ! (2, num_points) - lon, lat
+        integer, allocatable :: indices(:)   ! original indices
+        logical, allocatable :: valid(:)     ! valid flags
+    end type kdtree
+    
+contains
+
+    ! Build k-d tree from valid points
+    subroutine build_kdtree(tree, target_center_lon, target_center_lat, valid_cells)
+        type(kdtree), intent(out) :: tree
+        real(8), intent(in) :: target_center_lon(:), target_center_lat(:)
+        logical, intent(in) :: valid_cells(:)
+        
+        integer :: i, valid_count, idx
+        integer, allocatable :: temp_indices(:)
+        
+        ! Count valid points
+        valid_count = count(valid_cells)
+        tree%num_points = valid_count
+        
+        if (valid_count == 0) return
+        
+        ! Allocate arrays
+        allocate(tree%points(2, valid_count))
+        allocate(tree%indices(valid_count))
+        allocate(tree%valid(valid_count))
+        allocate(temp_indices(valid_count))
+        
+        ! Copy valid points
+        idx = 1
+        do i = 1, size(valid_cells)
+            if (valid_cells(i)) then
+                tree%points(1, idx) = target_center_lon(i)
+                tree%points(2, idx) = target_center_lat(i)
+                tree%indices(idx) = i
+                tree%valid(idx) = .true.
+                temp_indices(idx) = idx
+                idx = idx + 1
+            end if
+        end do
+        
+        ! Build the tree
+        tree%root => build_node(tree, temp_indices, 1, valid_count, 1)
+        
+        deallocate(temp_indices)
+    end subroutine build_kdtree
+
+    ! Recursive function to build k-d tree nodes
+    recursive function build_node(tree, indices, start_idx, end_idx, depth) result(node)
+        type(kdtree), intent(inout) :: tree
+        integer, intent(inout) :: indices(:)
+        integer, intent(in) :: start_idx, end_idx, depth
+        type(kdtree_node), pointer :: node
+        
+        integer :: median_idx, split_dim, i
+        
+        if (start_idx > end_idx) then
+            node => null()
+            return
+        end if
+        
+        allocate(node)
+        
+        ! Determine split dimension (alternate between lon and lat)
+        split_dim = mod(depth - 1, 2) + 1
+        node%split_dim = split_dim
+        
+        if (start_idx == end_idx) then
+            ! Leaf node
+            node%point_idx = indices(start_idx)
+            node%coords(1) = tree%points(1, indices(start_idx))
+            node%coords(2) = tree%points(2, indices(start_idx))
+            node%left => null()
+            node%right => null()
+        else
+            ! Find median and partition
+            median_idx = (start_idx + end_idx) / 2
+            call quickselect(tree, indices, start_idx, end_idx, median_idx, split_dim)
+            
+            node%point_idx = indices(median_idx)
+            node%coords(1) = tree%points(1, indices(median_idx))
+            node%coords(2) = tree%points(2, indices(median_idx))
+            
+            ! Recursively build left and right subtrees
+            node%left => build_node(tree, indices, start_idx, median_idx - 1, depth + 1)
+            node%right => build_node(tree, indices, median_idx + 1, end_idx, depth + 1)
+        end if
+    end function build_node
+
+    ! Quickselect algorithm to find median
+    recursive subroutine quickselect(tree, indices, left, right, k, dim)
+        type(kdtree), intent(in) :: tree
+        integer, intent(inout) :: indices(:)
+        integer, intent(in) :: left, right, k, dim
+        
+        integer :: pivot_idx, new_pivot_idx
+        
+        if (left >= right) return
+        
+        pivot_idx = partition(tree, indices, left, right, dim)
+        
+        if (k == pivot_idx) then
+            return
+        else if (k < pivot_idx) then
+            call quickselect(tree, indices, left, pivot_idx - 1, k, dim)
+        else
+            call quickselect(tree, indices, pivot_idx + 1, right, k, dim)
+        end if
+    end subroutine quickselect
+
+    ! Partition function for quickselect
+    function partition(tree, indices, left, right, dim) result(pivot_idx)
+        type(kdtree), intent(in) :: tree
+        integer, intent(inout) :: indices(:)
+        integer, intent(in) :: left, right, dim
+        integer :: pivot_idx
+        
+        real(8) :: pivot_value
+        integer :: i, store_idx, temp
+        
+        ! Use rightmost element as pivot
+        pivot_value = tree%points(dim, indices(right))
+        store_idx = left
+        
+        do i = left, right - 1
+            if (tree%points(dim, indices(i)) <= pivot_value) then
+                ! Swap
+                temp = indices(i)
+                indices(i) = indices(store_idx)
+                indices(store_idx) = temp
+                store_idx = store_idx + 1
+            end if
+        end do
+        
+        ! Move pivot to final position
+        temp = indices(right)
+        indices(right) = indices(store_idx)
+        indices(store_idx) = temp
+        
+        pivot_idx = store_idx
+    end function partition
+
+    ! Find nearest neighbor
+    function find_nearest_neighbor_kdtree(tree, query_lon, query_lat, exclude_idx) result(nearest_idx)
+        type(kdtree), intent(in) :: tree
+        real(8), intent(in) :: query_lon, query_lat
+        integer, intent(in), optional :: exclude_idx
+        integer :: nearest_idx
+        
+        real(8) :: query_point(2)
+        real(8) :: best_dist_sq
+        integer :: best_idx, exclude_id
+        
+        if (.not. associated(tree%root)) then
+            nearest_idx = -1
+            return
+        end if
+        
+        query_point(1) = query_lon
+        query_point(2) = query_lat
+        best_dist_sq = huge(1.0d0)
+        best_idx = -1
+        
+        exclude_id = -1
+        if (present(exclude_idx)) exclude_id = exclude_idx
+        
+        call search_nearest(tree, tree%root, query_point, best_dist_sq, best_idx, exclude_id)
+        
+        if (best_idx > 0) then
+            nearest_idx = tree%indices(best_idx)
+        else
+            nearest_idx = -1
+        end if
+    end function find_nearest_neighbor_kdtree
+
+    ! Recursive nearest neighbor search
+    recursive subroutine search_nearest(tree, node, query_point, best_dist_sq, best_idx, exclude_idx)
+        type(kdtree), intent(in) :: tree
+        type(kdtree_node), pointer, intent(in) :: node
+        real(8), intent(in) :: query_point(2)
+        real(8), intent(inout) :: best_dist_sq
+        integer, intent(inout) :: best_idx
+        integer, intent(in) :: exclude_idx
+        
+        real(8) :: dist_sq, diff_sq
+        type(kdtree_node), pointer :: first_child, second_child
+        
+        if (.not. associated(node)) return
+        
+        ! Calculate distance to current node
+        dist_sq = (node%coords(1) - query_point(1))**2 + (node%coords(2) - query_point(2))**2
+        
+        ! Update best if this is better and not excluded
+        if (dist_sq < best_dist_sq .and. tree%indices(node%point_idx) /= exclude_idx) then
+            best_dist_sq = dist_sq
+            best_idx = node%point_idx
+        end if
+        
+        ! Determine which child to search first
+        if (query_point(node%split_dim) <= node%coords(node%split_dim)) then
+            first_child => node%left
+            second_child => node%right
+        else
+            first_child => node%right
+            second_child => node%left
+        end if
+        
+        ! Search the closer child first
+        call search_nearest(tree, first_child, query_point, best_dist_sq, best_idx, exclude_idx)
+        
+        ! Check if we need to search the other child
+        diff_sq = (query_point(node%split_dim) - node%coords(node%split_dim))**2
+        if (diff_sq < best_dist_sq) then
+            call search_nearest(tree, second_child, query_point, best_dist_sq, best_idx, exclude_idx)
+        end if
+    end subroutine search_nearest
+
+    ! Clean up k-d tree memory
+    subroutine destroy_kdtree(tree)
+        type(kdtree), intent(inout) :: tree
+        
+        if (associated(tree%root)) then
+            call destroy_node(tree%root)
+        end if
+        
+        if (allocated(tree%points)) deallocate(tree%points)
+        if (allocated(tree%indices)) deallocate(tree%indices)
+        if (allocated(tree%valid)) deallocate(tree%valid)
+        
+        tree%num_points = 0
+    end subroutine destroy_kdtree
+
+    ! Recursive node destruction
+    recursive subroutine destroy_node(node)
+        type(kdtree_node), pointer :: node
+        
+        if (.not. associated(node)) return
+        
+        call destroy_node(node%left)
+        call destroy_node(node%right)
+        deallocate(node)
+        node => null()
+    end subroutine destroy_node
+
+end module kdtree_mod

--- a/cube_to_target/kdtree_mod.F90
+++ b/cube_to_target/kdtree_mod.F90
@@ -66,7 +66,7 @@ contains
         integer, intent(in) :: start_idx, end_idx, depth
         type(kdtree_node), pointer :: node
         
-        integer :: median_idx, split_dim, i
+        integer :: median_idx, split_dim
         
         if (start_idx > end_idx) then
             node => null()
@@ -107,7 +107,7 @@ contains
         integer, intent(inout) :: indices(:)
         integer, intent(in) :: left, right, k, dim
         
-        integer :: pivot_idx, new_pivot_idx
+        integer :: pivot_idx 
         
         if (left >= right) return
         

--- a/cube_to_target/neighbor_search_mod.F90
+++ b/cube_to_target/neighbor_search_mod.F90
@@ -70,14 +70,18 @@ MODULE neighbor_search_mod
         integer :: ii, jj, k, idx, iblock, jblock, search_radius
         real(8) :: min_dist, dist, dlat, dlon
         logical :: found_valid
+        real(8) :: lat_i, lon_i
 
         min_dist = 1.0d30
         closest = -1
         found_valid = .false.
         search_radius = 1
 
-        iblock = min(num_lon_blocks, max(1, int(target_center_lon(i) / lon_block_size) + 1))
-        jblock = min(num_lat_blocks, max(1, int((target_center_lat(i) + 90.0d0) / lat_block_size) + 1))
+        lat_i = target_center_lat(i)
+        lon_i = target_center_lon(i)
+
+        iblock = min(num_lon_blocks, max(1, int(lon_i / lon_block_size) + 1))
+        jblock = min(num_lat_blocks, max(1, int((lat_i + 90.0d0) / lat_block_size) + 1))
 
         do while (.not. found_valid .and. search_radius <= max_search_radius)
           do ii = max(1, iblock - search_radius), min(num_lon_blocks, iblock + search_radius)
@@ -85,9 +89,9 @@ MODULE neighbor_search_mod
                   do k = 1, blocks(ii,jj)%num_cells
                       idx = blocks(ii,jj)%indices(k)
                       if (valid_cells(idx) .and. idx /= i) then  ! exclude the problematic cell itself
-                          dlat = target_center_lat(idx) - target_center_lat(i)
-                          dlon = target_center_lon(idx) - target_center_lon(i)
-                          dist = dlat**2 + dlon**2
+                          dlat = target_center_lat(idx) - lat_i
+                          dlon = target_center_lon(idx) - lon_i
+                          dist = dlat*dlat + dlon*dlon
                           if (dist < min_dist) then
                               min_dist = dist
                               closest = idx
@@ -110,4 +114,3 @@ MODULE neighbor_search_mod
     end function find_nearest_valid_neighbor
 
 END MODULE neighbor_search_mod
-

--- a/cube_to_target/neighbor_search_mod.F90
+++ b/cube_to_target/neighbor_search_mod.F90
@@ -1,0 +1,113 @@
+MODULE neighbor_search_mod
+  IMPLICIT NONE
+
+    type BlockType
+      integer, allocatable :: indices(:)
+      integer :: num_cells
+     end type BlockType
+  CONTAINS
+   !====================================================================================
+   ! Function: find_nearest_valid_neighbor
+   !
+   ! Purpose:
+   !   Identify the nearest valid neighboring cell to a specified problematic cell
+   !   within a structured block-based spatial search. Primarily used for correcting
+   !   invalid or extreme values (fallback mechanism) by replacing them with
+   !   geographically nearby, valid cell values.
+   !
+   ! Arguments:
+   !   integer, intent(in) :: i
+   !       Index of the problematic target cell that requires a valid neighbor.
+   !
+   !   real(8), intent(in) :: target_center_lon(:), target_center_lat(:)
+   !       Arrays containing the longitudes (0–360 degrees) and latitudes (-90–90 degrees)
+   !       of target grid cell centers.
+   !
+   !   logical, intent(in) :: valid_cells(:)
+   !       Logical mask array indicating validity status of target grid cells:
+   !       .true. if cell is valid, .false. otherwise.
+   !
+   !   integer, intent(in) :: num_lon_blocks, num_lat_blocks
+   !       Total number of spatial blocks dividing the target grid longitudinally
+   !       and latitudinally, respectively, used to accelerate the neighbor search.
+   !
+   !   real(8), intent(in) :: lon_block_size, lat_block_size
+   !       Size (in degrees) of each spatial block along longitude and latitude.
+   !
+   !   type(BlockType), intent(in) :: blocks(:,:)
+   !       2-dimensional array of BlockType structures, each containing indices
+   !       of cells within its spatial block and the number of cells (`num_cells`).
+   !
+   !   integer, intent(in) :: max_search_radius
+   !       Maximum number of blocks around the current block to search for a valid neighbor.
+   !
+   ! Returns:
+   !   integer :: closest
+   !       Index of the nearest valid neighboring cell found.
+   !       Returns -1 if no valid neighbor is identified within the specified search radius.
+   !
+   ! Implementation details:
+   !   - Spatial search is conducted incrementally by expanding radius around the problematic cell’s block.
+   !   - Distances are computed based on simple squared Euclidean lat-lon differences.
+   !   - The first valid cell found with minimal distance is selected as the neighbor.
+   !   - Ensures robustness in stretched and irregular grids by systematically
+   !     and efficiently locating fallback values.
+   !
+   ! Notes:
+   !   - This function is critical for maintaining physical consistency in the final
+   !     topography data, preventing anomalous elevations due to invalid cells seen with stretched grid runs.
+   !====================================================================================
+
+    function find_nearest_valid_neighbor(i, target_center_lon, target_center_lat, valid_cells, &
+                                         num_lon_blocks, num_lat_blocks, lon_block_size, lat_block_size, &
+                                         blocks, max_search_radius) result(closest)
+        integer, intent(in) :: i, num_lon_blocks, num_lat_blocks
+        real(8), intent(in) :: target_center_lon(:), target_center_lat(:), lon_block_size, lat_block_size
+        logical, intent(in) :: valid_cells(:)
+        type(BlockType), intent(in) :: blocks(:,:)
+        integer, intent(in) :: max_search_radius
+        integer :: closest
+        integer :: ii, jj, k, idx, iblock, jblock, search_radius
+        real(8) :: min_dist, dist, dlat, dlon
+        logical :: found_valid
+
+        min_dist = 1.0d30
+        closest = -1
+        found_valid = .false.
+        search_radius = 1
+
+        iblock = min(num_lon_blocks, max(1, int(target_center_lon(i) / lon_block_size) + 1))
+        jblock = min(num_lat_blocks, max(1, int((target_center_lat(i) + 90.0d0) / lat_block_size) + 1))
+
+        do while (.not. found_valid .and. search_radius <= max_search_radius)
+          do ii = max(1, iblock - search_radius), min(num_lon_blocks, iblock + search_radius)
+              do jj = max(1, jblock - search_radius), min(num_lat_blocks, jblock + search_radius)
+                  do k = 1, blocks(ii,jj)%num_cells
+                      idx = blocks(ii,jj)%indices(k)
+                      if (valid_cells(idx) .and. idx /= i) then  ! exclude the problematic cell itself
+                          dlat = target_center_lat(idx) - target_center_lat(i)
+                          dlon = target_center_lon(idx) - target_center_lon(i)
+                          dist = dlat**2 + dlon**2
+                          if (dist < min_dist) then
+                              min_dist = dist
+                              closest = idx
+                              found_valid = .true.
+                          end if
+                      endif
+                  end do
+              end do
+          end do
+            if (.not. found_valid) search_radius = search_radius + 1
+        end do
+
+       ! ! Simple confirmation print:
+       ! if (found_valid) then
+       !     write(*,*) "Nearest neighbor found for cell", i, "->", closest
+       ! else
+       !     write(*,*) "No nearest neighbor found for cell", i
+       !endif
+
+    end function find_nearest_valid_neighbor
+
+END MODULE neighbor_search_mod
+

--- a/cube_to_target/remap.F90
+++ b/cube_to_target/remap.F90
@@ -20,68 +20,165 @@ MODULE remap
 
   contains
 
-!===============================================================================
-!  remap_field
-!
-!  Purpose:
-!    Maps data from a cubed-sphere source grid (with flat 1D indexing) to a 
-!    lat/lon target grid using precomputed overlap weights. This function 
-!    is used to remap fields like terrain height, land fraction, etc.
-!
-!  Concepts:
-!    - Source grid ('eul'):    The equal-area cubed sphere (6 panels of ncube x ncube cells)
-!    - Target grid ('lgr'):    The destination grid, typically a spectral element grid
-!    - Exchange grid:          Virtual cells formed by intersecting source and target grids;
-!                              each remap weight corresponds to one exchange cell.
-!    - nreconstruction = 1:    This setting assumes piecewise constant values in each source cell
-!
-!  Inputs:
-!    - field:               Flattened source field (6 faces of the cube)
-!    - area_target:         Area of each target grid cell
-!    - weights_all:         Overlap weights (one per exchange-grid segment)
-!    - weights_eul_index_all: For each overlap segment, the (ix, iy, ipanel)
-!                             index into the source cubed-sphere field
-!    - weights_lgr_index_all: For each segment, the index of the target grid cell
-!    - ncube:               Resolution of cubed-sphere face
-!    - jall:                Number of overlap segments (dynamically filled)
-!    - nreconstruction:     Number of fields per segment (usually 1)
-!    - ntarget:             Number of target grid cells
-!
-!  Output:
-!    - f(ntarget):          The resulting remapped field on the target grid
-!
-!  Notes:
-!    - Assumes all inputs are valid and consistent
-!    - Performs index and area safety checks for robustness
-!    - Compatible with stretched grid remapping
-!
-!===============================================================================
 
+!*******************************************************************************
+  !
+  ! Begin calculation of overlap weights
+  !
+  !*******************************************************************************
+  ! Concepts:
+  !    source grid ('eul') : Cells on which data (e.g. elevation) is provided.
+  !                          Here this grid is the equal-area cubed sphere with 
+  !                          6 panels of ncube x ncube cells
+  !
+  !    target grid ('lgr') : Cells to which data is mapped from 'eul'. Here
+  !                          this will normally be a spectral element grid with
+  !                          ntarget cells
+  !
+  !    exchange grid       : Cells formed by cutting the source grid and target 
+  !                          grid through each other. The number of cells in this 
+  !                          grid is difficult to know a-priori. Will be determined
+  !                          in subroutine overlap_weights
+  !                    
+  !    nreconstruction     : Here set to 1 (a few lines above). Order of subgrid reconstruction
+  !                          function in source grid cells. 1 means assumed piecewise constant 
+  !                          in source cells
+  !
+  !********************************************************************************
+
+
+
+    function remap_field(field,area_target,weights_eul_index_all,weights_lgr_index_all,weights_all,ncube,jall,&
+         nreconstruction,ntarget) result(f)
+      use shr_kind_mod, only: r8 => shr_kind_r8, i8 => shr_kind_i8
+      implicit none
+      real(r8), intent(in) :: weights_all(jall,nreconstruction)
+      integer , intent(in) :: weights_eul_index_all(jall,3),weights_lgr_index_all(jall)
+      integer , intent(in) :: ncube,nreconstruction,ntarget
+      real(r8), intent(in) :: field(6*ncube*ncube),area_target(ntarget)
+      real(r8):: f(ntarget)
+      integer(i8), intent(in) :: jall
+      integer(i8)  :: counti
+
+
+      integer :: i,ix,iy,ip,ii
+      real(r8):: wt
+
+      f=0.0D0
+      do counti=1_i8,jall
+        i    = weights_lgr_index_all(counti)
+
+        ix  = weights_eul_index_all(counti,1)
+        iy  = weights_eul_index_all(counti,2)
+        ip  = weights_eul_index_all(counti,3)
+
+        ! Safety check to avoid out-of-bounds indexing
+        if (i < 1 .or. i > ntarget) cycle
+        if (ix < 1 .or. ix > ncube) cycle
+        if (iy < 1 .or. iy > ncube) cycle
+        if (ip < 1 .or. ip > 6) cycle
+
+        !
+        ! convert to 1D indexing of cubed-sphere
+        !
+        ii = (ip-1)*ncube*ncube+(iy-1)*ncube+ix
+        if (ii < 1 .or. ii > 6*ncube*ncube) cycle
+
+        wt = weights_all(counti,1)
+
+        ! Note:  Factor wt/area_target(i) is fractional overlap of target and source grid
+        ! cells
+        !
+        f(i) = f(i) + wt*field(ii)/area_target(i)
+  end do
+end function remap_field
+
+
+!===============================================================================
+!                       remap_field_stretched
+!
+! Purpose:
+!   Remaps data from a cubed-sphere source grid onto a stretched lat/lon target grid
+!   using precomputed overlap weights. This version handles stretched-grid specific 
+!   scenarios, explicitly correcting problematic or invalid cells using nearest-neighbor 
+!   fallback logic.
+!
+! Concepts:
+!   - Source grid ('eul'):    Equal-area cubed-sphere grid (6 panels, ncube x ncube cells per panel)
+!   - Target grid ('lgr'):    Destination grid specifically refined for stretched-grid configurations
+!   - Exchange grid:          Virtual cells created by intersecting source and stretched target grids;
+!                             each overlap segment contributes to the target grid values.
+!   - Nearest-neighbor fallback: Robust method to handle invalid cells specific to stretched-grid geometries.
+!
+! Inputs:
+!   - field:                  Flattened source field (6 cubed-sphere panels)
+!   - area_target:            Area of each stretched-grid target cell
+!   - weights_all:            Overlap weights for each exchange segment
+!   - weights_eul_index_all:  Source cell indices (ix, iy, ipanel) for each overlap segment
+!   - weights_lgr_index_all:  Target grid cell indices for each overlap segment
+!   - ncube:                  Resolution (number of cells per face) of the cubed-sphere
+!   - jall:                   Total number of overlap segments
+!   - nreconstruction:        Reconstruction order (typically 1)
+!   - ntarget:                Total number of cells in the stretched target grid
+!   - target_center_lon:      Longitude of target cell centers (stretched-grid)
+!   - target_center_lat:      Latitude of target cell centers (stretched-grid)
+!   - valid_cells:            Logical mask indicating valid (non-fallback) cells in the stretched grid
+!   - num_lon_blocks:         Number of longitude blocks used for nearest-neighbor search
+!   - num_lat_blocks:         Number of latitude blocks used for nearest-neighbor search
+!   - lon_block_size:         Longitude size of blocks for spatial indexing
+!   - lat_block_size:         Latitude size of blocks for spatial indexing
+!   - blocks:                 Spatial indexing blocks (for efficient nearest-neighbor search)
+!
+! Output:
+!   - f(ntarget):             Remapped field on the stretched target grid
+!
+! Notes:
+!   - Designed specifically for robust handling of stretched-grid remapping scenarios.
+!   - Ensures problematic cells (invalid area, unrealistic values) are replaced using 
+!     nearest-neighbor logic to preserve physical consistency.
+!
+!===============================================================================
   
-  function remap_field(field, area_target, weights_eul_index_all, weights_lgr_index_all, weights_all, ncube, jall, nreconstruction, ntarget) result(f)
-    use shr_kind_mod, only: r8 => shr_kind_r8,i8 => shr_kind_i8
+  function remap_field_stretched(field, area_target, weights_eul_index_all, weights_lgr_index_all, &
+                                 weights_all, ncube, jall, nreconstruction, ntarget, &
+                                 target_center_lon, target_center_lat, valid_cells, &
+                                 num_lon_blocks, num_lat_blocks, lon_block_size, lat_block_size, blocks) result(f)
+  
+    use shr_kind_mod, only: r8 => shr_kind_r8, i8 => shr_kind_i8
+    use neighbor_search_mod, ONLY: BlockType, find_nearest_valid_neighbor
     implicit none
   
     ! Input arguments
-    real(r8), intent(in) :: field(6*ncube*ncube)         ! Flattened field over cubed sphere
-    real(r8), intent(in) :: area_target(ntarget)         ! Area of each target grid cell
-    real(r8), intent(in) :: weights_all(:,:)             ! Overlap weights per segment (jall, nreconstruction)
-    integer , intent(in) :: weights_eul_index_all(:,:)   ! Indices of cube grid cells (jall, 3)
-    integer , intent(in) :: weights_lgr_index_all(:)     ! Target grid cell indices (jall)
-    integer , intent(in) :: ncube, nreconstruction, ntarget
+    real(r8), intent(in) :: field(6*ncube*ncube)           ! Flattened field over cubed sphere
+    real(r8), intent(in) :: area_target(ntarget)           ! Area of each target grid cell
+    real(r8), intent(in) :: weights_all(:,:)               ! Overlap weights per segment (jall, nreconstruction)
+    integer, intent(in) :: weights_eul_index_all(:,:)      ! Indices of cube grid cells (jall, 3)
+    integer, intent(in) :: weights_lgr_index_all(:)        ! Target grid cell indices (jall)
+    integer, intent(in) :: ncube, nreconstruction, ntarget
     integer(i8), intent(in) :: jall
+    integer(i8)  :: counti
+  
+    real(r8), intent(in) :: target_center_lon(ntarget), target_center_lat(ntarget)
+    logical, intent(in) :: valid_cells(ntarget)
+    integer, intent(in) :: num_lon_blocks, num_lat_blocks
+    real(r8), intent(in) :: lon_block_size, lat_block_size
+    type(BlockType), intent(in) :: blocks(:,:)
   
     ! Output
-    real(r8) :: f(ntarget)                               ! Result field mapped onto target grid
+    real(r8) :: f(ntarget)
   
-    ! Locals
-    integer :: i, ix, iy, ip, ii, counti
+    ! Local variables
+    integer :: i, ix, iy, ip, ii, closest
     real(r8) :: wt
+    real(r8), allocatable :: total_weight(:)
   
-    f = 0.0_r8    ! Initialize result field to zero
+    ! Allocate and initialize total_weight
+    allocate(total_weight(ntarget))
+    f = 0.0_r8
+    total_weight = 0.0_r8
   
     ! Loop over each overlap segment and accumulate weighted contributions
-    do counti = 1, jall
+    do counti = 1_i8, jall
       i  = weights_lgr_index_all(counti)        ! Target cell index
       ix = weights_eul_index_all(counti,1)      ! Cube x-index
       iy = weights_eul_index_all(counti,2)      ! Cube y-index
@@ -92,7 +189,11 @@ MODULE remap
       if (ix < 1 .or. ix > ncube) cycle
       if (iy < 1 .or. iy > ncube) cycle
       if (ip < 1 .or. ip > 6)     cycle
-      if (area_target(i) <= 0.0_r8) cycle
+  
+      if (area_target(i) <= 0.0_r8) then
+        write(*,*) "Warning: cell", i, "has zero or negative area_target:", area_target(i)
+        cycle
+      endif
   
       ! Convert (ix,iy,ip) triple to flat index
       ii = (ip - 1) * ncube * ncube + (iy - 1) * ncube + ix
@@ -100,15 +201,39 @@ MODULE remap
   
       ! Compute weight contribution from this overlap segment
       wt = weights_all(counti, 1)
+
+      ! Accumulate normally, including negatives
       f(i) = f(i) + wt * field(ii) / area_target(i)
+      total_weight(i) = total_weight(i) + wt
     end do
   
-  end function remap_field
+    ! After all cells calculated, fix problematic cells explicitly using nearest neighbor assignment
+    do i = 1, ntarget
+      if (f(i) > 8848.0_r8 .or. f(i) < -423.0_r8 .or. total_weight(i) <= 0.0_r8) then
+        write(*,*) "Problematic final value for cell", i, ":", f(i), "weights sum:", total_weight(i)
+  
+        ! Robust nearest-neighbor fallback
+        closest = find_nearest_valid_neighbor(i, target_center_lon, target_center_lat, valid_cells, &
+                                              num_lon_blocks, num_lat_blocks, lon_block_size, lat_block_size, &
+                                              blocks, 100)
+        if (closest > 0) then
+          f(i) = f(closest)
+          write(*,*) "Cell", i, "assigned from neighbor cell", closest, "value:", f(closest)
+        else
+          f(i) = 0.0_r8  ! Final fallback to ocean
+          write(*,*) "No valid neighbor found for cell", i, "— set to ocean value (0.0)"
+        endif
+      endif
+    end do
+  
+    deallocate(total_weight)
+  
+  end function remap_field_stretched
 
 !==============================================================================================================
     function select_sg_field(field,weights_eul_index_all,weights_lgr_index_all,ncube,jall,&
          ntarget,itarget) result(ird)
-      use shr_kind_mod, only: r8 => shr_kind_r8
+      use shr_kind_mod, only: r8 => shr_kind_r8, i8 => shr_kind_i8
       implicit none
       integer , intent(in) :: weights_eul_index_all(jall,3),weights_lgr_index_all(jall)
       integer , intent(in) :: ncube,jall,ntarget,itarget
@@ -116,14 +241,15 @@ MODULE remap
       ! real(r8):: fsg(6*ncube*ncube)
       
       
-      integer :: i,ix,iy,ip,ii,counti
+      integer :: i,ix,iy,ip,ii
       real(r8):: wt
       real(r8):: ftarget(ntarget)
       integer :: ijp3(10000,3),ird
+      integer (i8) :: counti
       
       ird=1
       !!fsg=0.0D0
-      do counti=1,jall
+      do counti=1_i8,jall
         i    = weights_lgr_index_all(counti)
 
         if (itarget == i) then        
@@ -155,7 +281,7 @@ end function select_sg_field
 !==============================================================================================================
     function paint_sg_field(field,weights_eul_index_all,weights_lgr_index_all,ncube,jall,&
          ntarget,itarget) result(isg)
-      use shr_kind_mod, only: r8 => shr_kind_r8
+      use shr_kind_mod, only: r8 => shr_kind_r8, i8 => shr_kind_i8
       implicit none
       integer , intent(in) :: weights_eul_index_all(jall,3),weights_lgr_index_all(jall)
       integer , intent(in) :: ncube,jall,ntarget,itarget
@@ -163,14 +289,15 @@ end function select_sg_field
       integer :: isg(6*ncube*ncube)
       
       
-      integer :: i,ix,iy,ip,ii,counti
+      integer :: i,ix,iy,ip,ii
+      integer (i8) :: counti
       real(r8):: wt
       real(r8):: ftarget(ntarget)
       integer :: ijp3(10000,3),ird
       
       ird=1
       isg=-1
-      do counti=1,jall
+      do counti=1_i8,jall
         i    = weights_lgr_index_all(counti)
         
            ix  = weights_eul_index_all(counti,1)
@@ -254,7 +381,6 @@ end function paint_sg_field
     !
     ! this module assumes that cells are specified clockwise (not counter-clockwise); CHECK
     !
-
     signed_area=0.0
     do i=1,nvertex
 !      signed_area=signed_area+xcell_in(i)*ycell_in(i+1)-xcell_in(i+1)*ycell(i)
@@ -311,7 +437,6 @@ end function paint_sg_field
 
     xcell = xcell_in(1:nvertex)
     ycell = ycell_in(1:nvertex)
-
     !
     ! this is to avoid ill-conditioning problems
     !

--- a/cube_to_target/remap.F90
+++ b/cube_to_target/remap.F90
@@ -142,10 +142,12 @@ end function remap_field
   function remap_field_stretched(field, area_target, weights_eul_index_all, weights_lgr_index_all, &
                                  weights_all, ncube, jall, nreconstruction, ntarget, &
                                  target_center_lon, target_center_lat, valid_cells, &
-                                 num_lon_blocks, num_lat_blocks, lon_block_size, lat_block_size, blocks) result(f)
+                                 num_lon_blocks, num_lat_blocks, lon_block_size, lat_block_size, blocks, &
+                                 tree, use_block_neighbor_search) result(f)
   
     use shr_kind_mod, only: r8 => shr_kind_r8, i8 => shr_kind_i8
     use neighbor_search_mod, ONLY: BlockType, find_nearest_valid_neighbor
+    use kdtree_mod
     implicit none
   
     ! Input arguments
@@ -163,6 +165,8 @@ end function remap_field
     integer, intent(in) :: num_lon_blocks, num_lat_blocks
     real(r8), intent(in) :: lon_block_size, lat_block_size
     type(BlockType), intent(in) :: blocks(:,:)
+    type(kdtree),  intent(in)    :: tree
+    logical, intent(in) :: use_block_neighbor_search
   
     ! Output
     real(r8) :: f(ntarget)
@@ -213,9 +217,14 @@ end function remap_field
         write(*,*) "Problematic final value for cell", i, ":", f(i), "weights sum:", total_weight(i)
   
         ! Robust nearest-neighbor fallback
-        closest = find_nearest_valid_neighbor(i, target_center_lon, target_center_lat, valid_cells, &
+        if (use_block_neighbor_search) then
+           closest = find_nearest_valid_neighbor(i, target_center_lon, target_center_lat, valid_cells, &
                                               num_lon_blocks, num_lat_blocks, lon_block_size, lat_block_size, &
                                               blocks, 100)
+        else  ! use k-d tree search
+           closest = find_nearest_neighbor_kdtree(tree, target_center_lon(i), target_center_lat(i), i)
+        end if
+        write(400,*) i, target_center_lon(i), target_center_lat(i), closest
         if (closest > 0) then
           f(i) = f(closest)
           write(*,*) "Cell", i, "assigned from neighbor cell", closest, "value:", f(closest)

--- a/cube_to_target/remap.F90
+++ b/cube_to_target/remap.F90
@@ -250,8 +250,6 @@ end function remap_field
       
       
       integer :: i,ix,iy,ip,ii
-      real(r8):: wt
-      real(r8):: ftarget(ntarget)
       integer :: ijp3(10000,3),ird
       integer (i8) :: counti
       
@@ -270,8 +268,6 @@ end function remap_field
           !
           ii = (ip-1)*ncube*ncube+(iy-1)*ncube+ix
         
-        
-          ! Note:  Factor wt/area_target(i) is fractional overlap of target and source grid
           ! cells
           !
           ijp3(ird,1) = ix
@@ -296,12 +292,9 @@ end function select_sg_field
       real(r8), intent(in) :: field(6*ncube*ncube)
       integer :: isg(6*ncube*ncube)
       
-      
+      integer :: ird 
       integer :: i,ix,iy,ip,ii
       integer (i8) :: counti
-      real(r8):: wt
-      real(r8):: ftarget(ntarget)
-      integer :: ijp3(10000,3),ird
       
       ird=1
       isg=-1

--- a/cube_to_target/remap.F90
+++ b/cube_to_target/remap.F90
@@ -224,7 +224,6 @@ end function remap_field
         else  ! use k-d tree search
            closest = find_nearest_neighbor_kdtree(tree, target_center_lon(i), target_center_lat(i), i)
         end if
-        write(400,*) i, target_center_lon(i), target_center_lat(i), closest
         if (closest > 0) then
           f(i) = f(closest)
           write(*,*) "Cell", i, "assigned from neighbor cell", closest, "value:", f(closest)

--- a/cube_to_target/remap.F90
+++ b/cube_to_target/remap.F90
@@ -20,71 +20,90 @@ MODULE remap
 
   contains
 
+!===============================================================================
+!  remap_field
+!
+!  Purpose:
+!    Maps data from a cubed-sphere source grid (with flat 1D indexing) to a 
+!    lat/lon target grid using precomputed overlap weights. This function 
+!    is used to remap fields like terrain height, land fraction, etc.
+!
+!  Concepts:
+!    - Source grid ('eul'):    The equal-area cubed sphere (6 panels of ncube x ncube cells)
+!    - Target grid ('lgr'):    The destination grid, typically a spectral element grid
+!    - Exchange grid:          Virtual cells formed by intersecting source and target grids;
+!                              each remap weight corresponds to one exchange cell.
+!    - nreconstruction = 1:    This setting assumes piecewise constant values in each source cell
+!
+!  Inputs:
+!    - field:               Flattened source field (6 faces of the cube)
+!    - area_target:         Area of each target grid cell
+!    - weights_all:         Overlap weights (one per exchange-grid segment)
+!    - weights_eul_index_all: For each overlap segment, the (ix, iy, ipanel)
+!                             index into the source cubed-sphere field
+!    - weights_lgr_index_all: For each segment, the index of the target grid cell
+!    - ncube:               Resolution of cubed-sphere face
+!    - jall:                Number of overlap segments (dynamically filled)
+!    - nreconstruction:     Number of fields per segment (usually 1)
+!    - ntarget:             Number of target grid cells
+!
+!  Output:
+!    - f(ntarget):          The resulting remapped field on the target grid
+!
+!  Notes:
+!    - Assumes all inputs are valid and consistent
+!    - Performs index and area safety checks for robustness
+!    - Compatible with stretched grid remapping
+!
+!===============================================================================
 
-  !*******************************************************************************
-  !
-  ! Begin calculation of overlap weights
-  !
-  !*******************************************************************************
-  ! Concepts:
-  !    source grid ('eul') : Cells on which data (e.g. elevation) is provided.
-  !                          Here this grid is the equal-area cubed sphere with 
-  !                          6 panels of ncube x ncube cells
-  !
-  !    target grid ('lgr') : Cells to which data is mapped from 'eul'. Here
-  !                          this will normally be a spectral element grid with
-  !                          ntarget cells
-  !
-  !    exchange grid       : Cells formed by cutting the source grid and target 
-  !                          grid through each other. The number of cells in this 
-  !                          grid is difficult to know a-priori. Will be determined
-  !                          in subroutine overlap_weights
-  !                    
-  !    nreconstruction     : Here set to 1 (a few lines above). Order of subgrid reconstruction
-  !                          function in source grid cells. 1 means assumed piecewise constant 
-  !                          in source cells
-  !
-  !********************************************************************************
-
-
-
-    function remap_field(field,area_target,weights_eul_index_all,weights_lgr_index_all,weights_all,ncube,jall,&
-         nreconstruction,ntarget) result(f)
-      use shr_kind_mod, only: r8 => shr_kind_r8
-      implicit none
-      real(r8), intent(in) :: weights_all(jall,nreconstruction)
-      integer , intent(in) :: weights_eul_index_all(jall,3),weights_lgr_index_all(jall)
-      integer , intent(in) :: ncube,jall,nreconstruction,ntarget
-      real(r8), intent(in) :: field(6*ncube*ncube),area_target(ntarget)
-      real(r8):: f(ntarget)
-      
-      
-      integer :: i,ix,iy,ip,ii,counti
-      real(r8):: wt
-      real(r8):: ftarget(ntarget)
-      
-      f=0.0D0
-      do counti=1,jall
-        i    = weights_lgr_index_all(counti)
-        
-        ix  = weights_eul_index_all(counti,1)
-        iy  = weights_eul_index_all(counti,2)
-        ip  = weights_eul_index_all(counti,3)
-
-        !
-        ! convert to 1D indexing of cubed-sphere
-        !
-        ii = (ip-1)*ncube*ncube+(iy-1)*ncube+ix
-        
-        wt = weights_all(counti,1)
-        
-        ! Note:  Factor wt/area_target(i) is fractional overlap of target and source grid
-        ! cells
-        !
-        f(i) = f(i) + wt*field(ii)/area_target(i)
-  end do
-end function remap_field
-
+  
+  function remap_field(field, area_target, weights_eul_index_all, weights_lgr_index_all, weights_all, ncube, jall, nreconstruction, ntarget) result(f)
+    use shr_kind_mod, only: r8 => shr_kind_r8,i8 => shr_kind_i8
+    implicit none
+  
+    ! Input arguments
+    real(r8), intent(in) :: field(6*ncube*ncube)         ! Flattened field over cubed sphere
+    real(r8), intent(in) :: area_target(ntarget)         ! Area of each target grid cell
+    real(r8), intent(in) :: weights_all(:,:)             ! Overlap weights per segment (jall, nreconstruction)
+    integer , intent(in) :: weights_eul_index_all(:,:)   ! Indices of cube grid cells (jall, 3)
+    integer , intent(in) :: weights_lgr_index_all(:)     ! Target grid cell indices (jall)
+    integer , intent(in) :: ncube, nreconstruction, ntarget
+    integer(i8), intent(in) :: jall
+  
+    ! Output
+    real(r8) :: f(ntarget)                               ! Result field mapped onto target grid
+  
+    ! Locals
+    integer :: i, ix, iy, ip, ii, counti
+    real(r8) :: wt
+  
+    f = 0.0_r8    ! Initialize result field to zero
+  
+    ! Loop over each overlap segment and accumulate weighted contributions
+    do counti = 1, jall
+      i  = weights_lgr_index_all(counti)        ! Target cell index
+      ix = weights_eul_index_all(counti,1)      ! Cube x-index
+      iy = weights_eul_index_all(counti,2)      ! Cube y-index
+      ip = weights_eul_index_all(counti,3)      ! Cube panel index (1–6)
+  
+      ! Skip invalid indices
+      if (i < 1 .or. i > ntarget) cycle
+      if (ix < 1 .or. ix > ncube) cycle
+      if (iy < 1 .or. iy > ncube) cycle
+      if (ip < 1 .or. ip > 6)     cycle
+      if (area_target(i) <= 0.0_r8) cycle
+  
+      ! Convert (ix,iy,ip) triple to flat index
+      ii = (ip - 1) * ncube * ncube + (iy - 1) * ncube + ix
+      if (ii < 1 .or. ii > 6*ncube*ncube) cycle
+  
+      ! Compute weight contribution from this overlap segment
+      wt = weights_all(counti, 1)
+      f(i) = f(i) + wt * field(ii) / area_target(i)
+    end do
+  
+  end function remap_field
 
 !==============================================================================================================
     function select_sg_field(field,weights_eul_index_all,weights_lgr_index_all,ncube,jall,&
@@ -235,12 +254,14 @@ end function paint_sg_field
     !
     ! this module assumes that cells are specified clockwise (not counter-clockwise); CHECK
     !
+
     signed_area=0.0
     do i=1,nvertex
 !      signed_area=signed_area+xcell_in(i)*ycell_in(i+1)-xcell_in(i+1)*ycell(i)
       signed_area=signed_area+(xcell_in(i+1)+xcell_in(i))*(ycell_in(i+1)-ycell_in(i))
     end do
     signed_area=0.5*signed_area
+
     if (signed_area>0.0) then
       write(*,*) "area must be clockwise (and counter clockwise in input file)"
       do i=0,nvertex
@@ -291,13 +312,13 @@ end function paint_sg_field
     xcell = xcell_in(1:nvertex)
     ycell = ycell_in(1:nvertex)
 
-
     !
     ! this is to avoid ill-conditioning problems
     !
     eps = 1.0E-9
 
     jsegment = 0
+
     weights  = 0.0D0
     jcross_lat = 0
     !
@@ -313,7 +334,6 @@ end function paint_sg_field
       STOP
     END IF
 
-    
     call side_integral(xcell,ycell,nvertex,jsegment,jmax_segments,&
          weights,weights_eul_index,nreconstruction,jx,jy,xgno,ygno,jx_min, jx_max, jy_min, jy_max,&
          ngauss,gauss_weights,abscissae,&
@@ -340,6 +360,7 @@ end function paint_sg_field
     ! collect line-segment that reside in the same Eulerian cell
     !
     if (jsegment>0) then
+
       call collect(weights,weights_eul_index,nreconstruction,jcollect,jsegment,jmax_segments)
       !
       ! DBG

--- a/cube_to_target/ridge_ana.F90
+++ b/cube_to_target/ridge_ana.F90
@@ -2607,12 +2607,12 @@ function paintridge2cube ( axr, ncube,nhalo,nsw, lzerovalley, crest_length, cres
    integer(kind=8) :: tclock1, tclock2, clock_rate
    real(kind=8) :: elapsed_time
    call system_clock(tclock1)
-!!!$omp parallel do ordered default(none)  &
-!!!$omp private(ipk,suba,ncl,rotangl,subr,subdis,NSWx,dsq,jj,ii,ip, &
-!!!$omp x0,y0,subq,nhw,jw,subblk0,subblk,sub1) &
-!!!$omp shared(npeaks,mxdis,Lcrestwt,clngth,nsw, &
-!!!$omp Lcrestln,anglx,axr,allpixels,xs,ys,xspk,yspk, &
-!!!$omp nhalo,ncube,QC,AXC,hwdth,sub11,RefFac,peaks)
+!$omp parallel do ordered default(none)  &
+!$omp private(ipk,suba,ncl,rotangl,subr,subdis,NSWx,dsq,jj,ii,ip, &
+!$omp x0,y0,subq,nhw,jw,subblk0,subblk,sub1) &
+!$omp shared(npeaks,mxdis,Lcrestwt,clngth,nsw, &
+!$omp Lcrestln,anglx,axr,allpixels,xs,ys,xspk,yspk, &
+!$omp nhalo,ncube,QC,AXC,hwdth,sub11,RefFac,peaks)
    do ipk=1,npeaks
         if(mxdis(ipk)>=1.0) then
  
@@ -2673,9 +2673,13 @@ function paintridge2cube ( axr, ncube,nhalo,nsw, lzerovalley, crest_length, cres
                 y0 = INT( yspk(ipk) ) + 1  ! original, original has +1
                 !x0 = INT( xspk(ipk) )      ! why do we need +1 
                 !y0 = INT( yspk(ipk) )
-                if ( (x0+ii>=1-nhalo).and.(x0+ii<=ncube+nhalo).AND.(Y0+ii>=1-nhalo).and.(Y0+ii<=ncube+nhalo) ) then
-                       if ( QC( x0+ii, y0+jj, ip ) <= subq(ii,jj) )  AXC( x0+ii, y0+jj, ip ) = subdis(ii,jj)
-                       if ( QC( x0+ii, y0+jj, ip ) <= subq(ii,jj) )  QC( x0+ii, y0+jj, ip )  = subq(ii,jj)
+                if ( (x0+ii>=1-nhalo).and.(x0+ii<=ncube+nhalo).AND.(Y0+jj>=1-nhalo).and.(Y0+jj<=ncube+nhalo) ) then
+                      !$OMP CRITICAL
+                       if ( QC( x0+ii, y0+jj, ip ) <= subq(ii,jj) )  then 
+                          AXC( x0+ii, y0+jj, ip ) = subdis(ii,jj)
+                          QC( x0+ii, y0+jj, ip )  = subq(ii,jj)
+                      endif
+                      !$OMP END CRITICAL
                 endif
              end do
              end do
@@ -2724,9 +2728,13 @@ function paintridge2cube ( axr, ncube,nhalo,nsw, lzerovalley, crest_length, cres
                 !y0 = INT( yspk(ipk) )  
                 x0 = NINT( 1.*xspk(ipk) )      ! do we need +1 
                 y0 = NINT( 1.*yspk(ipk) )  
-                if ( (x0+ii>=1-nhalo).and.(x0+ii<=ncube+nhalo).AND.(Y0+ii>=1-nhalo).and.(Y0+ii<=ncube+nhalo) ) then
-                       if (subblk(ii,jj) >= QC( x0+ii, y0+jj, ip ))  AXC( x0+ii, y0+jj, ip ) = subdis(ii,jj)
-                       if (subblk(ii,jj) >= QC( x0+ii, y0+jj, ip ))   QC( x0+ii, y0+jj, ip ) = subblk(ii,jj)
+                if ( (x0+ii>=1-nhalo).and.(x0+ii<=ncube+nhalo).AND.(Y0+jj>=1-nhalo).and.(Y0+jj<=ncube+nhalo) ) then
+                      !$OMP CRITICAL
+                      if (subblk(ii,jj) >= QC( x0+ii, y0+jj, ip )) then
+                          AXC( x0+ii, y0+jj, ip ) = subdis(ii,jj)
+                          QC( x0+ii, y0+jj, ip ) = subblk(ii,jj)
+                      endif
+                      !$OMP END CRITICAL
                  endif
              end do
              end do
@@ -2739,8 +2747,12 @@ function paintridge2cube ( axr, ncube,nhalo,nsw, lzerovalley, crest_length, cres
                 ip = peaks(ipk)%ip
                 x0 = INT( xspk(ipk) )
                 y0 = INT( yspk(ipk) )
-                if ( (x0+ii>=1-nhalo).and.(x0+ii<=ncube+nhalo).AND.(Y0+ii>=1-nhalo).and.(Y0+ii<=ncube+nhalo) ) then
-                       if (subdis(ii,jj) >= AXC( x0+ii, y0+jj, ip ))  AXC( x0+ii, y0+jj, ip ) = subdis(ii,jj)
+                if ( (x0+ii>=1-nhalo).and.(x0+ii<=ncube+nhalo).AND.(Y0+jj>=1-nhalo).and.(Y0+jj<=ncube+nhalo) ) then
+                      !$OMP CRITICAL
+                      if (subdis(ii,jj) >= AXC( x0+ii, y0+jj, ip )) then
+                          AXC( x0+ii, y0+jj, ip ) = subdis(ii,jj)
+                      endif
+                      !$OMP END CRITICAL
                  endif
              end do
              end do

--- a/cube_to_target/ridge_ana.F90
+++ b/cube_to_target/ridge_ana.F90
@@ -391,11 +391,6 @@ subroutine find_ridges ( terr_dev, terr_raw, ncube, nhalo, nsw,     &
     do_refine = .FALSE.
     if(present(lregional_refinement)) do_refine = lregional_refinement
 
-    if(do_refine) then
-      write(*,*) "regional refinement not merged - ABORT"
-      !STOP
-    end if
-
     npeaks = size( peaks% i )
    
 write(*,*) " size of peaks in find_ridge ", npeaks
@@ -1116,7 +1111,7 @@ end subroutine THINOUT_LIST
 !                      fv_0.9x1.25_nc3000_Nsw042_Nrs008_Co060_Fi001_20211102.nc
 !===========================================
 
-      use shr_kind_mod, only: r8 => shr_kind_r8
+      use shr_kind_mod, only: r8 => shr_kind_r8, i8 => shr_kind_i8
       use remap
       use reconstruct !, only : EquiangularAllAreas
       implicit none
@@ -1141,7 +1136,7 @@ end subroutine THINOUT_LIST
       
       integer :: alloc_error
 
-      integer :: i,ix,iy,ip,ii,counti,norx,nory,i_last,isubr,iip,j,ipk,npeaks
+      integer :: i,ix,iy,ip,ii,norx,nory,i_last,isubr,iip,j,ipk,npeaks
       integer :: nswx,nrs_junk
       real(r8):: wt
       real(KIND=dbl_kind), dimension(1-nhalo:ncube+nhalo,1-nhalo:ncube+nhalo ,6) :: tmpx6
@@ -1155,6 +1150,7 @@ end subroutine THINOUT_LIST
       CHARACTER(len=1024) :: ofile
       character(len=8)  :: date
       character(len=10) :: time
+      integer(i8)  :: counti
 
 !----------------------------------------------------------------------------------------------------
 
@@ -1345,6 +1341,7 @@ end subroutine THINOUT_LIST
       logical,            intent(in) :: ldevelopment_diags
       logical,            optional, intent(in) :: lregional_refinement
       real(kind=dbl_kind),optional, intent(in) :: rr_factor(:,:,:)
+      integer(i8)                              :: counti
       logical :: use_rr
 
       integer,dimension(ncube*ncube*6),intent(out)  :: itrgtC
@@ -1364,7 +1361,7 @@ end subroutine THINOUT_LIST
         
       integer :: alloc_error
 
-      integer :: i,ix,iy,ip,ii,counti,norx,nory,i_last,isubr,iip,j,ipk,npeaks
+      integer :: i,ix,iy,ip,ii,norx,nory,i_last,isubr,iip,j,ipk,npeaks
       integer :: nswx,nrs_junk
       real(r8):: wt
       !!real(KIND=dbl_kind), dimension(ncube*ncube*6) :: itrgtC, itrgxC
@@ -1437,7 +1434,7 @@ end subroutine THINOUT_LIST
 !      In the following loop "counti" is the index of a piece of 
 !      the "exchange grid" - created by cutting the cubed-sphere topo
 !      and target grid into each other.  
-    do counti=1,jall
+    do counti=1_i8,jall
      
       i    = weights_lgr_index_all(counti)
 
@@ -1447,16 +1444,22 @@ end subroutine THINOUT_LIST
       !
       ! convert to 1D indexing of cubed-sphere
       !
+      if (ix<1 .or. ix>ncube .or. iy<1 .or. iy>ncube .or. ip<1 .or. ip>6) cycle
       ii = (ip-1)*ncube*ncube+(iy-1)*ncube+ix
+      if (ii<1 .or. ii>6*ncube*ncube) cycle
       
       wt = weights_all(counti,1) * wgt(ix,iy,ip)   ! add for stretched grid,  multiply by refinement weight
 
       iip=(iy-1)*ncube+ix
+      if (iip<1 .or. iip>ncube*ncube) cycle
 
-      itrgtC(ii) = i
-      if (mxdisC(ii) > 0.1)  itrgxC(ii) = i
-      isubr = INT( anglxC(ii) * nsubr/180. ) + 1
-      if ( (isubr >= 1).and.(isubr <= nsubr) ) then
+      isubr = max(1, min(nsubr, INT( anglxC(ii) * nsubr/180. ) + 1))
+
+      !itrgtC(ii) = i
+      !if (mxdisC(ii) > 0.1)  itrgxC(ii) = i
+      !isubr = INT( anglxC(ii) * nsubr/180. ) + 1
+      !if ( (isubr >= 1).and.(isubr <= nsubr) ) then
+      if (i>=1 .and. i<=ntarget .and. isubr>=1 .and. isubr<=nsubr) then
       wghts_target( i , isubr ) = wghts_target( i , isubr ) + wt
       hwdth_target( i , isubr ) = hwdth_target( i , isubr ) + wt*hwdthC(ii)
       mxvrx_target( i , isubr ) = mxvrx_target( i , isubr ) + wt*mxvrxC(ii)
@@ -1469,6 +1472,8 @@ end subroutine THINOUT_LIST
       count_target( i , isubr ) = count_target( i , isubr ) + wt/dA(iip)
       fallq_target( i , isubr ) = fallq_target( i , isubr ) + wt*fallqC(ii)
       riseq_target( i , isubr ) = riseq_target( i , isubr ) + wt*riseqC(ii)
+      else 
+      write(*,*) "Index out-of-bounds detected, skipping contribution:", i, isubr
       endif
 
       i_last = i
@@ -1523,7 +1528,7 @@ end subroutine THINOUT_LIST
 !      In the following loop "counti" is the index of a piece of 
 !      the "exchange grid" - created by cutting the cubed-sphere topo
 !      and target grid into each other.  
-    do counti=1,jall
+    do counti=1_i8,jall
        i    = weights_lgr_index_all(counti)
 
        ix  = weights_eul_index_all(counti,1)
@@ -1532,7 +1537,11 @@ end subroutine THINOUT_LIST
        !
        ! convert to 1D indexing of cubed-sphere
        !
+       ! Check bounds explicitly
+       if (ix<1 .or. ix>ncube .or. iy<1 .or. iy>ncube .or. ip<1 .or. ip>6) cycle
        ii = (ip-1)*ncube*ncube+(iy-1)*ncube+ix
+       if (ii<1 .or. ii>6*ncube*ncube) cycle
+       if (i<1 .or. i>ntarget) cycle       
 
        wt = weights_all(counti,1) * wgt(ix,iy,ip)   ! add for stretched grid,  multiply by refinement weight
 
@@ -1605,7 +1614,7 @@ end subroutine THINOUT_LIST
         
       integer :: alloc_error
       integer :: npack,NobMin,NobMax,iir,iic,maxtiles,npeaks
-      integer :: i,ix,iy,ip,ii,counti,norx,nory,i_last,isubr,iip,j,ipk,ir
+      integer :: i,ix,iy,ip,ii,norx,nory,i_last,isubr,iip,j,ipk,ir
       integer :: nswx,nrs_junk,ig,nalloc,n,ird,ThisRidge,k,nf1,nf2,IdxMin,IdxMax
       real(r8):: wt,wght
       integer,             dimension(ncube*ncube*6) :: xcoord,ycoord,pcoord
@@ -1638,6 +1647,7 @@ end subroutine THINOUT_LIST
       real(kind=dbl_kind),optional, intent(in) :: rr_factor(:,:,:)
       real(r8), allocatable, dimension(:) :: wgtPack
       logical :: use_rr
+      integer(i8)  :: counti
 
       use_rr = present(lregional_refinement) .and. lregional_refinement
 
@@ -1676,7 +1686,7 @@ end subroutine THINOUT_LIST
       MyCrests  = 0
       LnCrests  = 0._r8
 
-      do counti=1,jall
+      do counti=1_i8,jall
          i   = weights_lgr_index_all(counti)
          ix  = weights_eul_index_all(counti,1)
          iy  = weights_eul_index_all(counti,2)
@@ -1684,7 +1694,11 @@ end subroutine THINOUT_LIST
          !
          ! convert to 1D indexing of cubed-sphere
          !
+         if (ix<1 .or. ix>ncube .or. iy<1 .or. iy>ncube .or. ip<1 .or. ip>6) cycle
          ii = (ip-1)*ncube*ncube+(iy-1)*ncube+ix
+         if (ii<1 .or. ii>6*ncube*ncube) cycle
+         if (i<1 .or. i>ntarget) cycle         
+
          if (itrgtC(ii)==i) then
             idcoun(i)   = idcoun(i)+1
             idxmap(idcoun(i),i)= ii

--- a/cube_to_target/ridge_ana.F90
+++ b/cube_to_target/ridge_ana.F90
@@ -2607,12 +2607,12 @@ function paintridge2cube ( axr, ncube,nhalo,nsw, lzerovalley, crest_length, cres
    integer(kind=8) :: tclock1, tclock2, clock_rate
    real(kind=8) :: elapsed_time
    call system_clock(tclock1)
-!$omp parallel do ordered default(none)  &
-!$omp private(ipk,suba,ncl,rotangl,subr,subdis,NSWx,dsq,jj,ii,ip, &
-!$omp x0,y0,subq,nhw,jw,subblk0,subblk,sub1) &
-!$omp shared(npeaks,mxdis,Lcrestwt,clngth,nsw, &
-!$omp Lcrestln,anglx,axr,allpixels,xs,ys,xspk,yspk, &
-!$omp nhalo,ncube,QC,AXC,hwdth,sub11,RefFac,peaks)
+!!$omp parallel do ordered default(none)  &
+!!$omp private(ipk,suba,ncl,rotangl,subr,subdis,NSWx,dsq,jj,ii,ip, &
+!!$omp x0,y0,subq,nhw,jw,subblk0,subblk,sub1) &
+!!$omp shared(npeaks,mxdis,Lcrestwt,clngth,nsw, &
+!!$omp Lcrestln,anglx,axr,allpixels,xs,ys,xspk,yspk, &
+!!$omp nhalo,ncube,QC,AXC,hwdth,sub11,RefFac,peaks)
    do ipk=1,npeaks
         if(mxdis(ipk)>=1.0) then
  

--- a/cube_to_target/ridge_ana.F90
+++ b/cube_to_target/ridge_ana.F90
@@ -2613,7 +2613,7 @@ function paintridge2cube ( axr, ncube,nhalo,nsw, lzerovalley, crest_length, cres
 !!$omp shared(npeaks,mxdis,Lcrestwt,clngth,nsw, &
 !!$omp Lcrestln,anglx,axr,allpixels,xs,ys,xspk,yspk, &
 !!$omp nhalo,ncube,QC,AXC,hwdth,sub11,RefFac,peaks)
-   do ipk=1,npeaks
+  do ipk=1,npeaks
         if(mxdis(ipk)>=1.0) then
  
             if(Lcrestwt) then
@@ -2674,12 +2674,8 @@ function paintridge2cube ( axr, ncube,nhalo,nsw, lzerovalley, crest_length, cres
                 !x0 = INT( xspk(ipk) )      ! why do we need +1 
                 !y0 = INT( yspk(ipk) )
                 if ( (x0+ii>=1-nhalo).and.(x0+ii<=ncube+nhalo).AND.(Y0+jj>=1-nhalo).and.(Y0+jj<=ncube+nhalo) ) then
-                      !$OMP CRITICAL
-                       if ( QC( x0+ii, y0+jj, ip ) <= subq(ii,jj) )  then 
-                          AXC( x0+ii, y0+jj, ip ) = subdis(ii,jj)
-                          QC( x0+ii, y0+jj, ip )  = subq(ii,jj)
-                      endif
-                      !$OMP END CRITICAL
+                       if ( QC( x0+ii, y0+jj, ip ) <= subq(ii,jj) )  AXC( x0+ii, y0+jj, ip ) = subdis(ii,jj)
+                       if ( QC( x0+ii, y0+jj, ip ) <= subq(ii,jj) )  QC( x0+ii, y0+jj, ip )  = subq(ii,jj)
                 endif
              end do
              end do
@@ -2729,12 +2725,8 @@ function paintridge2cube ( axr, ncube,nhalo,nsw, lzerovalley, crest_length, cres
                 x0 = NINT( 1.*xspk(ipk) )      ! do we need +1 
                 y0 = NINT( 1.*yspk(ipk) )  
                 if ( (x0+ii>=1-nhalo).and.(x0+ii<=ncube+nhalo).AND.(Y0+jj>=1-nhalo).and.(Y0+jj<=ncube+nhalo) ) then
-                      !$OMP CRITICAL
-                      if (subblk(ii,jj) >= QC( x0+ii, y0+jj, ip )) then
-                          AXC( x0+ii, y0+jj, ip ) = subdis(ii,jj)
-                          QC( x0+ii, y0+jj, ip ) = subblk(ii,jj)
-                      endif
-                      !$OMP END CRITICAL
+                       if (subblk(ii,jj) >= QC( x0+ii, y0+jj, ip ))  AXC( x0+ii, y0+jj, ip ) = subdis(ii,jj)
+                       if (subblk(ii,jj) >= QC( x0+ii, y0+jj, ip ))   QC( x0+ii, y0+jj, ip ) = subblk(ii,jj)
                  endif
              end do
              end do
@@ -2748,17 +2740,13 @@ function paintridge2cube ( axr, ncube,nhalo,nsw, lzerovalley, crest_length, cres
                 x0 = INT( xspk(ipk) )
                 y0 = INT( yspk(ipk) )
                 if ( (x0+ii>=1-nhalo).and.(x0+ii<=ncube+nhalo).AND.(Y0+jj>=1-nhalo).and.(Y0+jj<=ncube+nhalo) ) then
-                      !$OMP CRITICAL
-                      if (subdis(ii,jj) >= AXC( x0+ii, y0+jj, ip )) then
-                          AXC( x0+ii, y0+jj, ip ) = subdis(ii,jj)
-                      endif
-                      !$OMP END CRITICAL
+                       if (subdis(ii,jj) >= AXC( x0+ii, y0+jj, ip ))  AXC( x0+ii, y0+jj, ip ) = subdis(ii,jj)
                  endif
              end do
              end do
              end if
-        end if
-   end do
+          end if
+      end do
    call system_clock(tclock2, clock_rate)
    elapsed_time = real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8)
    print *, 'Elapsed time paintridge2cube = ', elapsed_time, ' seconds.'

--- a/cube_to_target/ridge_ana.F90
+++ b/cube_to_target/ridge_ana.F90
@@ -2621,7 +2621,7 @@ function paintridge2cube ( axr, ncube,nhalo,nsw, lzerovalley, crest_length, cres
                 y0 = INT( yspk(ipk) ) + 1  ! original, original has +1
                 !x0 = INT( xspk(ipk) )      ! why do we need +1 
                 !y0 = INT( yspk(ipk) )
-                if ( (x0+ii>=1-nhalo).and.(x0+ii<=ncube+nhalo).AND.(Y0+ii>=1-nhalo).and.(Y0+ii<=ncube+nhalo) ) then
+                if ( (x0+ii>=1-nhalo).and.(x0+ii<=ncube+nhalo).AND.(Y0+jj>=1-nhalo).and.(Y0+jj<=ncube+nhalo) ) then
                        if ( QC( x0+ii, y0+jj, ip ) <= subq(ii,jj) )  AXC( x0+ii, y0+jj, ip ) = subdis(ii,jj)
                        if ( QC( x0+ii, y0+jj, ip ) <= subq(ii,jj) )  QC( x0+ii, y0+jj, ip )  = subq(ii,jj)
                 endif
@@ -2672,7 +2672,7 @@ function paintridge2cube ( axr, ncube,nhalo,nsw, lzerovalley, crest_length, cres
                 !y0 = INT( yspk(ipk) )  
                 x0 = NINT( 1.*xspk(ipk) )      ! do we need +1 
                 y0 = NINT( 1.*yspk(ipk) )  
-                if ( (x0+ii>=1-nhalo).and.(x0+ii<=ncube+nhalo).AND.(Y0+ii>=1-nhalo).and.(Y0+ii<=ncube+nhalo) ) then
+                if ( (x0+ii>=1-nhalo).and.(x0+ii<=ncube+nhalo).AND.(Y0+jj>=1-nhalo).and.(Y0+jj<=ncube+nhalo) ) then
                        if (subblk(ii,jj) >= QC( x0+ii, y0+jj, ip ))  AXC( x0+ii, y0+jj, ip ) = subdis(ii,jj)
                        if (subblk(ii,jj) >= QC( x0+ii, y0+jj, ip ))   QC( x0+ii, y0+jj, ip ) = subblk(ii,jj)
                  endif
@@ -2687,7 +2687,7 @@ function paintridge2cube ( axr, ncube,nhalo,nsw, lzerovalley, crest_length, cres
                 ip = peaks(ipk)%ip
                 x0 = INT( xspk(ipk) )
                 y0 = INT( yspk(ipk) )
-                if ( (x0+ii>=1-nhalo).and.(x0+ii<=ncube+nhalo).AND.(Y0+ii>=1-nhalo).and.(Y0+ii<=ncube+nhalo) ) then
+                if ( (x0+ii>=1-nhalo).and.(x0+ii<=ncube+nhalo).AND.(Y0+jj>=1-nhalo).and.(Y0+jj<=ncube+nhalo) ) then
                        if (subdis(ii,jj) >= AXC( x0+ii, y0+jj, ip ))  AXC( x0+ii, y0+jj, ip ) = subdis(ii,jj)
                  endif
              end do

--- a/cube_to_target/ridge_ana.F90
+++ b/cube_to_target/ridge_ana.F90
@@ -2284,7 +2284,7 @@ write(*,*) " in fleshout_block "
                 do ii = -NSWx/2,NSWx/2
                     x0 = i ! INT( xspk(ipk) ) + 1
                     y0 = j ! INT( yspk(ipk) ) + 1
-                    if ( (x0+ii>=1-nhalo).and.(x0+ii<=ncube+nhalo).AND.(Y0+ii>=1-nhalo).and.(Y0+ii<=ncube+nhalo) ) then
+                    if ( (x0+ii>=1-nhalo).and.(x0+ii<=ncube+nhalo).AND.(Y0+jj>=1-nhalo).and.(Y0+jj<=ncube+nhalo) ) then
                        if ( subdis(ii,jj) >=  AXC( x0+ii, y0+jj, ip ) )  AXC( x0+ii, y0+jj, ip ) = subdis(ii,jj)
                     end if
                 end do
@@ -2346,7 +2346,7 @@ function fleshout_profi ( ncube,nhalo,nsw,mxdisC,anglxC,uniqidC,rrfac,shape_x ) 
                 do ii = -NSWx/2,NSWx/2
                     x0 = i ! INT( xspk(ipk) ) + 1
                     y0 = j ! INT( yspk(ipk) ) + 1
-                    if ( (x0+ii>=1-nhalo).and.(x0+ii<=ncube+nhalo).AND.(Y0+ii>=1-nhalo).and.(Y0+ii<=ncube+nhalo) ) then
+                    if ( (x0+ii>=1-nhalo).and.(x0+ii<=ncube+nhalo).AND.(Y0+jj>=1-nhalo).and.(Y0+jj<=ncube+nhalo) ) then
                        if ( (subdis(ii,jj) <= 0.).and. (AXC( x0+ii, y0+jj, ip )<=0. ) ) then
                           if ( subdis(ii,jj) <=  AXC( x0+ii, y0+jj, ip ) )  AXC( x0+ii, y0+jj, ip ) = subdis(ii,jj)
                        else
@@ -2420,7 +2420,7 @@ function color_on_profi ( ncube,nhalo,nsw,mxdisC,anglxC,uniqidC,rrfac,shape_x,co
                 do ii = -NSWx/2,NSWx/2
                     x0 = i ! INT( xspk(ipk) ) + 1
                     y0 = j ! INT( yspk(ipk) ) + 1
-                    if ( (x0+ii>=1-nhalo).and.(x0+ii<=ncube+nhalo).AND.(Y0+ii>=1-nhalo).and.(Y0+ii<=ncube+nhalo) ) then
+                    if ( (x0+ii>=1-nhalo).and.(x0+ii<=ncube+nhalo).AND.(Y0+jj>=1-nhalo).and.(Y0+jj<=ncube+nhalo) ) then
                        if ( (subdis(ii,jj) <= 0.).and. (AXC( x0+ii, y0+jj, ip )<=0. ) ) then
                           if ( subdis(ii,jj) <=  AXC( x0+ii, y0+jj, ip ) ) then
                              AXC( x0+ii, y0+jj, ip ) = subdis(ii,jj)

--- a/cube_to_target/ridge_ana.F90
+++ b/cube_to_target/ridge_ana.F90
@@ -2279,6 +2279,10 @@ write(*,*) " in fleshout_block "
   real(kind=8) :: elapsed_time
   call system_clock(tclock1)
   do ip=1,6
+!$omp parallel do default(none) &
+!$omp shared(ncube,mxdisC,rrfac,AXC,ip,nsw,anglxC, &
+!$omp nhalo, hwdthC) &
+!$omp private(i,j,nswx,ipk,suba,subr,nhw,jw,rotangl,subdis,ii,jj,x0,y0)
   do j=1,ncube
   do i=1,ncube
      if(mxdisC(i,j,ip)>=1.0) then
@@ -2431,6 +2435,10 @@ function color_on_profi ( ncube,nhalo,nsw,mxdisC,anglxC,uniqidC,rrfac,shape_x,co
   real(kind=8) :: elapsed_time
   call system_clock(tclock1)
   do ip=1,6
+!$omp parallel do default(none) &
+!$omp shared(ncube,mxdisC,rrfac,uniqidC,shape_x,AXC,BXC,ip,nsw,anglxC, &
+!$omp psw,nhalo, colors) &
+!$omp private(i,j,nswx,ipk,suba,subr,jw,rotangl,subdis,ii,jj,x0,y0, subcolo)
   do j=1,ncube
   do i=1,ncube
      if(mxdisC(i,j,ip)>=1.0) then
@@ -2607,34 +2615,30 @@ function paintridge2cube ( axr, ncube,nhalo,nsw, lzerovalley, crest_length, cres
    integer(kind=8) :: tclock1, tclock2, clock_rate
    real(kind=8) :: elapsed_time
    call system_clock(tclock1)
-!!$omp parallel do ordered default(none)  &
-!!$omp private(ipk,suba,ncl,rotangl,subr,subdis,NSWx,dsq,jj,ii,ip, &
-!!$omp x0,y0,subq,nhw,jw,subblk0,subblk,sub1) &
-!!$omp shared(npeaks,mxdis,Lcrestwt,clngth,nsw, &
-!!$omp Lcrestln,anglx,axr,allpixels,xs,ys,xspk,yspk, &
-!!$omp nhalo,ncube,QC,AXC,hwdth,sub11,RefFac,peaks)
   do ipk=1,npeaks
         if(mxdis(ipk)>=1.0) then
  
+            rotangl = - anglx(ipk) 
+
             if(Lcrestwt) then
                suba(:,:) = 0.
                ncl  = MIN( INT(clngth(ipk)/2) , nsw/2 )
                suba( 0 , -ncl:ncl ) = 1.        
-               rotangl = - anglx(ipk) 
+               !rotangl = - anglx(ipk) 
                subr = rotbyx( suba , 2*nsw+1, rotangl )
                subdis = subr 
              else if(Lcrestln) then
                suba(:,:) = 0.
                ncl  = MIN( INT(clngth(ipk)/2) , nsw/2 )
                suba( 0 , -ncl:ncl ) = 1.        
-               rotangl = - anglx(ipk) 
+               !rotangl = - anglx(ipk) 
                subr = rotbyx( suba , 2*nsw+1, rotangl )
                subdis = subr * axr(ipk)
              else            
                suba(:,:) = 0.
                ncl  = MIN( INT(clngth(ipk)/2) , nsw/2 )
                suba( 0 , -ncl:ncl ) = 1.        
-               rotangl = - anglx(ipk) 
+               !rotangl = - anglx(ipk) 
                subr = rotbyx( suba , 2*nsw+1, rotangl )
                subdis =  subr * axr(ipk)
              end if
@@ -2642,7 +2646,7 @@ function paintridge2cube ( axr, ncube,nhalo,nsw, lzerovalley, crest_length, cres
 
 #ifdef ROTATEBRUSH
              ! rotated "brush"
-             rotangl = - anglx(ipk) 
+             !rotangl = - anglx(ipk) 
              sub1 = rotbyx( sub11 , 2*nsw+1, rotangl )
 #endif
 
@@ -2674,8 +2678,11 @@ function paintridge2cube ( axr, ncube,nhalo,nsw, lzerovalley, crest_length, cres
                 !x0 = INT( xspk(ipk) )      ! why do we need +1 
                 !y0 = INT( yspk(ipk) )
                 if ( (x0+ii>=1-nhalo).and.(x0+ii<=ncube+nhalo).AND.(Y0+jj>=1-nhalo).and.(Y0+jj<=ncube+nhalo) ) then
-                       if ( QC( x0+ii, y0+jj, ip ) <= subq(ii,jj) )  AXC( x0+ii, y0+jj, ip ) = subdis(ii,jj)
-                       if ( QC( x0+ii, y0+jj, ip ) <= subq(ii,jj) )  QC( x0+ii, y0+jj, ip )  = subq(ii,jj)
+                       if ( QC( x0+ii, y0+jj, ip ) <= subq(ii,jj) )  then
+                          AXC( x0+ii, y0+jj, ip ) = subdis(ii,jj)
+                          QC( x0+ii, y0+jj, ip )  = subq(ii,jj)
+                          !print '(a,9i6,2e12.4)', 'HERE  ',__LINE__, ipk, ip, x0, y0, ii,jj, peaks(ipk)%i,peaks(ipk)%j, subdis(ii,jj), subq(ii,jj)
+                       end if
                 endif
              end do
              end do
@@ -2684,7 +2691,7 @@ function paintridge2cube ( axr, ncube,nhalo,nsw, lzerovalley, crest_length, cres
              ! reconstruction/reconciliation based on a quality/amplitude
              ! measure in rotated rectangle (subblk)
              !------------------------------------------------------------
-             rotangl = - anglx(ipk) 
+             !rotangl = - anglx(ipk) 
              subblk0(:,:)=0.
              ncl  = MIN( INT(clngth(ipk)/2) , nsw/2 )
 
@@ -2725,8 +2732,11 @@ function paintridge2cube ( axr, ncube,nhalo,nsw, lzerovalley, crest_length, cres
                 x0 = NINT( 1.*xspk(ipk) )      ! do we need +1 
                 y0 = NINT( 1.*yspk(ipk) )  
                 if ( (x0+ii>=1-nhalo).and.(x0+ii<=ncube+nhalo).AND.(Y0+jj>=1-nhalo).and.(Y0+jj<=ncube+nhalo) ) then
-                       if (subblk(ii,jj) >= QC( x0+ii, y0+jj, ip ))  AXC( x0+ii, y0+jj, ip ) = subdis(ii,jj)
-                       if (subblk(ii,jj) >= QC( x0+ii, y0+jj, ip ))   QC( x0+ii, y0+jj, ip ) = subblk(ii,jj)
+                       if (subblk(ii,jj) >= QC( x0+ii, y0+jj, ip ))  then
+                          AXC( x0+ii, y0+jj, ip ) = subdis(ii,jj)
+                          QC( x0+ii, y0+jj, ip ) = subblk(ii,jj)
+                          !print '(a,9i6,2e12.4)', 'HERE  ',__LINE__, ipk, ip, x0, y0, ii,jj, peaks(ipk)%i,peaks(ipk)%j, subdis(ii,jj), subblk(ii,jj)
+                       end if
                  endif
              end do
              end do
@@ -2740,7 +2750,10 @@ function paintridge2cube ( axr, ncube,nhalo,nsw, lzerovalley, crest_length, cres
                 x0 = INT( xspk(ipk) )
                 y0 = INT( yspk(ipk) )
                 if ( (x0+ii>=1-nhalo).and.(x0+ii<=ncube+nhalo).AND.(Y0+jj>=1-nhalo).and.(Y0+jj<=ncube+nhalo) ) then
-                       if (subdis(ii,jj) >= AXC( x0+ii, y0+jj, ip ))  AXC( x0+ii, y0+jj, ip ) = subdis(ii,jj)
+                       if (subdis(ii,jj) >= AXC( x0+ii, y0+jj, ip ))  then
+                          AXC( x0+ii, y0+jj, ip ) = subdis(ii,jj)
+                          !print '(a,9i6,2e12.4)', 'HERE  ',__LINE__, ipk, ip, x0, y0, ii,jj, peaks(ipk)%i,peaks(ipk)%j, AXC( x0+ii, y0+jj, ip ), subdis(ii,jj)
+                       end if
                  endif
              end do
              end do

--- a/cube_to_target/ridge_ana.F90
+++ b/cube_to_target/ridge_ana.F90
@@ -130,7 +130,7 @@ subroutine find_local_maxes ( terr_dev, ncube, nhalo, nsw_in, iopt_ridge_seed,  
 
        INTEGER (KIND=int_kind), INTENT(IN)  :: ncube, nhalo ,nsw_in
        INTEGER (KIND=int_kind), INTENT(IN)  :: iopt_ridge_seed
-       INTEGER (KIND=int_kind) :: i,j,np,ncube_halo,ipanel,N,norx,nory,ip,nhigher,npeaks
+       INTEGER (KIND=int_kind) :: i,j,np,ncube_halo,ipanel,N,ip,nhigher,npeaks
        INTEGER (KIND=int_kind) :: ipk,nblock,ijaa(2),im,jm,bloc,ivar1,ivar2,ii,jj
 
     REAL(KIND=dbl_kind), &
@@ -355,7 +355,7 @@ subroutine find_ridges ( terr_dev, terr_raw, ncube, nhalo, nsw,     &
     !
     ! Local variables
     ! 
-    INTEGER (KIND=int_kind) :: i,j,np,ncube_halo,ipanel,N,norx,nory,ip,ipk,npeaks,nswx
+    INTEGER (KIND=int_kind) :: i,j,np,ncube_halo,ipanel,N,ip,ipk,npeaks,nswx
     INTEGER (KIND=int_kind) :: ispk,jspk
     INTEGER (KIND=int_kind) :: num_iter_ridge,iter_ridge,ns0,ns1
 
@@ -673,7 +673,7 @@ end subroutine find_ridges
   real(RPX) :: THETRAD,PI,swt,ang,rotmn,rotvar,mnt,var,xmn,xvr,basmn,basvar,mn2,var2
   real(RPX) :: dyr_crest
   real(RPX) :: xspk0 , yspk0
-  integer :: i,j,l,m,n2,mini,maxi,minj,maxj,ns0,ns1,iorn(1),jj
+  integer :: i,l,m,n2,mini,maxi,minj,maxj,ns0,ns1,iorn(1),jj
   integer :: ipkh(1),ivld(1),ift0(1),ift1(1),i2,ii,ipksv(1),nswx
   integer :: ibad_left,ibad_rght
   integer :: phase
@@ -1150,7 +1150,7 @@ end subroutine THINOUT_LIST
       
       integer :: alloc_error
 
-      integer :: i,ix,iy,ip,ii,norx,nory,i_last,isubr,iip,j,ipk,npeaks
+      integer :: i,ix,iy,ii,i_last,isubr,iip,ipk,npeaks
       integer :: nswx,nrs_junk
       real(r8):: wt
       real(KIND=dbl_kind), dimension(1-nhalo:ncube+nhalo,1-nhalo:ncube+nhalo ,6) :: tmpx6
@@ -1375,7 +1375,7 @@ end subroutine THINOUT_LIST
         
       integer :: alloc_error
 
-      integer :: i,ix,iy,ip,ii,norx,nory,i_last,isubr,iip,j,ipk,npeaks
+      integer :: i,ix,iy,ip,ii,i_last,isubr,iip,ipk,npeaks
       integer :: nswx,nrs_junk
       real(r8):: wt
       !!real(KIND=dbl_kind), dimension(ncube*ncube*6) :: itrgtC, itrgxC
@@ -1628,7 +1628,7 @@ end subroutine THINOUT_LIST
         
       integer :: alloc_error
       integer :: npack,NobMin,NobMax,iir,iic,maxtiles,npeaks
-      integer :: i,ix,iy,ip,ii,norx,nory,i_last,isubr,iip,j,ipk,ir
+      integer :: i,ix,iy,ip,ii,i_last,isubr,iip,j,ipk,ir
       integer :: nswx,nrs_junk,ig,nalloc,n,ird,ThisRidge,k,nf1,nf2,IdxMin,IdxMax
       real(r8):: wt,wght
       integer,             dimension(ncube*ncube*6) :: xcoord,ycoord,pcoord
@@ -2055,7 +2055,7 @@ end subroutine THINOUT_LIST
   real(r8) :: lat22s,lon22s,a22s,b22s
   real(r8) :: To_Radians
 
-  integer  :: i,j,isubr,ipanel22
+  integer  :: i,isubr,ipanel22
   integer  :: alloc_error
 
     if ( maxval( abs( target_center_lat )) > 2.0 ) then
@@ -2263,7 +2263,7 @@ function fleshout_block ( ncube,nhalo,nsw,mxdisC,hwdthC,anglxC,rrfac ) result( a
        real(rpx), dimension(-nsw:nsw,-nsw:nsw) :: subr,subq,subdis
        real(rpx), dimension(-nsw:nsw)          :: xq,yq
        real(RPX) :: rotangl,dsq,ssq
-       integer :: i,j,x0,x1,y0,y1,ip,ns0,ns1,ii,jj,norx,nory,nql,ncl,nhw,ipk,npeaks,jw,iw,nswx
+       integer :: i,j,x0,x1,y0,y1,ip,ns0,ns1,ii,jj,nql,ncl,nhw,ipk,npeaks,jw,iw,nswx
 !---------------------------------------------------
 
 
@@ -2339,7 +2339,7 @@ function fleshout_profi ( ncube,nhalo,nsw,mxdisC,anglxC,uniqidC,rrfac,shape_x ) 
        real(rpx), dimension(-nsw:nsw,-nsw:nsw) :: subr,subq,subdis
        real(rpx), dimension(-nsw:nsw)          :: xq,yq
        real(RPX) :: rotangl,dsq,ssq
-       integer :: i,j,x0,x1,y0,y1,ip,ns0,ns1,ii,jj,norx,nory,nql,ncl,nhw,ipk,npeaks,jw,iw,idx1,nswx
+       integer :: i,j,x0,x1,y0,y1,ip,ns0,ns1,ii,jj,nql,ncl,nhw,ipk,npeaks,jw,iw,idx1,nswx
 !---------------------------------------------------
 
 !===============================
@@ -2419,7 +2419,7 @@ function color_on_profi ( ncube,nhalo,nsw,mxdisC,anglxC,uniqidC,rrfac,shape_x,co
        real(rpx), dimension(-nsw:nsw,-nsw:nsw) :: subr,subq,subdis,subcolo
        real(rpx), dimension(-nsw:nsw)          :: xq,yq
        real(RPX) :: rotangl,dsq,ssq
-       integer :: i,j,x0,x1,y0,y1,ip,ns0,ns1,ii,jj,norx,nory,nql,ncl,nhw,ipk,npeaks,jw,iw,idx1,nswx
+       integer :: i,j,x0,x1,y0,y1,ip,ns0,ns1,ii,jj,nql,ncl,nhw,ipk,npeaks,jw,iw,idx1,nswx
 !---------------------------------------------------
 
  
@@ -2512,7 +2512,7 @@ function paintridge2cube ( axr, ncube,nhalo,nsw, lzerovalley, crest_length, cres
        real(rpx), dimension(-nsw:nsw,-nsw:nsw) :: subblk,subblk0
        real(rpx), dimension(-nsw:nsw)          :: xq,yq
        real(RPX) :: rotangl,dsq,ssq
-       integer :: i,j,x0,x1,y0,y1,ip,ns0,ns1,ii,jj,norx,nory,nql,ncl,nhw,ipk,npeaks,jw,iw,nswx
+       integer :: i,j,x0,x1,y0,y1,ip,ns0,ns1,ii,jj,nql,ncl,nhw,ipk,npeaks,jw,iw,nswx
        logical :: lcrestln,lcrestwt,lblockfl,lprofifl,lbumpfl,allpixels
 !---------------------------------------------------
 

--- a/cube_to_target/ridge_ana.F90
+++ b/cube_to_target/ridge_ana.F90
@@ -106,19 +106,29 @@ public peak_type
 contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-subroutine find_local_maxes ( terr_dev, ncube, nhalo, nsw, iopt_ridge_seed )
-!------------------------------------------------
-!  INPUTS.
-!      NSW = size of window used for ridge analysis
-!      
 
-    !type (peak_type), allocatable, dimension(:), intent(out) ::  peaks
-
+subroutine find_local_maxes ( terr_dev, ncube, nhalo, nsw_in, iopt_ridge_seed,  &
+                               lregional_refinement, rr_factor )
+!---------------------------------------------------------------
+!  Supports both regular and regional-refined grids:
+!    - In regular mode, nsw is constant (nsw = nsw_in)
+!    - In refined mode, nsw is scaled by refinement factor (rr_factor)
+!
+!  Inputs:
+!    - terr_dev(ncube,ncube,6)  : Terrain deviation field
+!    - ncube                    : Cube face dimension
+!    - nhalo                    : Halo width
+!    - nsw_in                   : User-specified smoothing window (before scaling)
+!    - iopt_ridge_seed          : Ridge detection method (1 = 3x3 diff, 2 = max block)
+!    - lregional_refinement     : (optional) enable refined cap logic
+!    - rr_factor(ncube,ncube,6) : (optional) regional refinement factor (> 1 in refined zones)
+!
+!---------------------------------------------------------------
 
     REAL(KIND=dbl_kind), &
             DIMENSION(ncube,ncube,6), INTENT(IN) :: terr_dev
 
-       INTEGER (KIND=int_kind), INTENT(IN)  :: ncube, nhalo, nsw
+       INTEGER (KIND=int_kind), INTENT(IN)  :: ncube, nhalo ,nsw_in
        INTEGER (KIND=int_kind), INTENT(IN)  :: iopt_ridge_seed
        INTEGER (KIND=int_kind) :: i,j,np,ncube_halo,ipanel,N,norx,nory,ip,nhigher,npeaks
        INTEGER (KIND=int_kind) :: ipk,nblock,ijaa(2),im,jm,bloc,ivar1,ivar2,ii,jj
@@ -142,11 +152,22 @@ subroutine find_local_maxes ( terr_dev, ncube, nhalo, nsw, iopt_ridge_seed )
     real(r8)  :: thsh
 
     CHARACTER(len=1024) :: ofile,ve
+   ! ---------- optional refinement flags ----------
+    logical,            optional       :: lregional_refinement
+    real(kind=dbl_kind),optional       :: rr_factor(:,:,:)
+    logical                             :: use_rr
+   ! ---------- local variables ----------
+    INTEGER (KIND=int_kind) :: nsw            ! adaptive window
 
 !---------------------------------------------------------------------------------------
 !  B E G I N   C A L C U L A T I O N S
 !---------------------------------------------------------------------------------------
 
+    use_rr = present(lregional_refinement) .and. lregional_refinement
+    nsw    = nsw_in
+    if (use_rr .and. present(rr_factor)) then
+       nsw = max(8, int(real(nsw_in)/maxval(rr_factor)))
+    end if
 
     DO np = 1, 6
      CALL CubedSphereFillHalo_Linear_extended(terr_dev, terr_dev_halo(:,:,np), np, ncube+1,nhalo)  
@@ -195,7 +216,6 @@ subroutine find_local_maxes ( terr_dev, ncube, nhalo, nsw, iopt_ridge_seed )
     if( iopt_ridge_seed == 2 ) then
     thsh = 10.
     bloc = MAX( 4 ,  NINT(nsw/8.) ) ! Think about floor of 4
-    !bloc = MAX( 2 ,  NINT(nsw/16.) ) ! Think about floor of 4
     allocate( aa(bloc+1,bloc+1) )
     write(*,*) " in find_local_max iopt_ridge_seed=2 "
     write(*,*) " ---> NSW , bloc ",nsw,bloc
@@ -445,13 +465,13 @@ write(*,*) " SHAPE ", shape( peaks%i )
 
       ncube_halo = size( terr_halo_r4, 1)
 
-   call alloc_ridge_qs(npeaks , NSW)
+   call alloc_ridge_qs(npeaks, NSW, lregional_refinement)
  
    do ipk = 1,npeaks
         i  = peaks(ipk)%i
         j  = peaks(ipk)%j
         np = peaks(ipk)%ip
-        MyPanel( ipk ) = np  ! could just write peaks%ip but WTF        
+        MyPanel( ipk ) = np  ! record panel for diagnostics        
 
 
 
@@ -462,13 +482,22 @@ write(*,*) " SHAPE ", shape( peaks%i )
         ! det(g) dependent ridge-finding window 
         nswx=  NINT( 1.*nsw / rdtg(i,j) )
 #endif
-        if(do_refine) nswx = NINT( nswx / rr_factor(i,j,np) )
-        if(do_refine) RefFac(ipk) = rr_factor(i,j,np) 
+        !--- shrink the brush on refined (Schmidt-stretched) refined faces -------
+        if (do_refine) then
+           nswx        = NINT( REAL(nswx) / rr_factor(i,j,np) )
+           RefFac(ipk) = rr_factor(i,j,np)
+        end if
 
-        !++jtb 05/26/24: Protection against too-small nswx
+        !++jtb 05/26/24: Protection against too-small nswx, never use a window smaller than 4×4
         nswx = MAX( 4 , nswx )
 
         NSWx_diag( ipk ) = nswx
+
+        !--- skip peaks whose window would step outside the halo ---------
+        if (lregional_refinement) then
+           if ( i-nswx < 1-nhalo .or. i+nswx > ncube+nhalo .or. &
+                j-nswx < 1-nhalo .or. j+nswx > ncube+nhalo ) cycle
+        end if        
 
              allocate( suba( 2*nswx+1 ,  2*nswx+1 ) )
              allocate( subarw( 2*nswx+1 ,  2*nswx+1 ) )
@@ -1294,7 +1323,7 @@ end subroutine THINOUT_LIST
          output_grid,ldevelopment_diags,terr_dev, &
          uniqidC,uniqwgC,anisoC,anglxC,mxdisC,hwdthC,clngtC, & 
          riseqC,fallqC,mxvrxC,mxvryC,nodesC,cwghtC, &
-         itrgtC )
+         itrgtC, lregional_refinement, rr_factor )
 !==========================================
 ! Some key inputs
 !      NSW:  = 'nwindow_halfwidth' which comes from topo namelist, but should always be 
@@ -1303,16 +1332,20 @@ end subroutine THINOUT_LIST
 !                      fv_0.9x1.25_nc3000_Nsw042_Nrs008_Co060_Fi001_20211102.nc
 !===========================================
 
-      use shr_kind_mod, only: r8 => shr_kind_r8
+      use shr_kind_mod, only: r8 => shr_kind_r8, i8 => shr_kind_i8
       use remap
       use reconstruct !, only : EquiangularAllAreas
       implicit none
       real(r8),           intent(in) :: weights_all(jall,nreconstruction)
       integer ,           intent(in) :: weights_eul_index_all(jall,3),weights_lgr_index_all(jall)
-      integer ,           intent(in) :: ncube,jall,nreconstruction,ntarget
+      integer ,           intent(in) :: ncube,nreconstruction,ntarget
+      integer(i8),        intent(in) :: jall
       real(r8),           intent(in) :: area_target(ntarget),target_center_lon(ntarget),target_center_lat(ntarget)
       character(len=1024),intent(in) :: output_grid
       logical,            intent(in) :: ldevelopment_diags
+      logical,            optional, intent(in) :: lregional_refinement
+      real(kind=dbl_kind),optional, intent(in) :: rr_factor(:,:,:)
+      logical :: use_rr
 
       integer,dimension(ncube*ncube*6),intent(out)  :: itrgtC
 
@@ -1344,6 +1377,7 @@ end subroutine THINOUT_LIST
       character(len=10) :: time
 
 !----------------------------------------------------------------------------------------------------
+      use_rr = present(lregional_refinement) .and. lregional_refinement
 
     !!allocate ( dA(ncube,ncube),stat=alloc_error )
     CALL EquiangularAllAreas(ncube, dA)
@@ -1414,7 +1448,8 @@ end subroutine THINOUT_LIST
       ! convert to 1D indexing of cubed-sphere
       !
       ii = (ip-1)*ncube*ncube+(iy-1)*ncube+ix
-      wt = weights_all(counti,1)
+      
+      wt = weights_all(counti,1) * wgt(ix,iy,ip)   ! add for stretched grid,  multiply by refinement weight
 
       iip=(iy-1)*ncube+ix
 
@@ -1498,7 +1533,9 @@ end subroutine THINOUT_LIST
        ! convert to 1D indexing of cubed-sphere
        !
        ii = (ip-1)*ncube*ncube+(iy-1)*ncube+ix
-       wt = weights_all(counti,1)
+
+       wt = weights_all(counti,1) * wgt(ix,iy,ip)   ! add for stretched grid,  multiply by refinement weight
+
        isovar_target( i ) = isovar_target( i ) + wt*( (tempC(ii)-terr_dev(ii))**2 )/area_target(i)
     end do
     isovar_target = SQRT( isovar_target )
@@ -1521,25 +1558,40 @@ end subroutine THINOUT_LIST
        
        write(*,*) " GOT OUT OF remapridge2target "
      end if
-
-       
-  end subroutine remapridge2target
-   
+    !------------------------------------------------------------------
+    contains
+       elemental real(kind=dbl_kind) function wgt(i,j,k)
+         integer, intent(in) :: i,j,k
+     
+         if ( use_rr               &
+          & .and. present(rr_factor)               &
+          & .and. i >= 1   .and. i <= size(rr_factor,1) &
+          & .and. j >= 1   .and. j <= size(rr_factor,2) &
+          & .and. k >= 1   .and. k <= size(rr_factor,3) ) then
+     
+           wgt = max( 1.0_dbl_kind, rr_factor(i,j,k) )
+         else
+           wgt = 1.0_dbl_kind
+         end if
+       end function wgt
+    !------------------------------------------------------------------
+    end subroutine remapridge2target  
 
 !====================================
    subroutine remapridge2tiles ( ntarget,ncube,jall,nreconstruction,     &
               area_target,target_center_lon,target_center_lat,         &
               weights_eul_index_all,weights_lgr_index_all,weights_all, &
-              uniqidC,uniqwgC,itrgtC,wedgoC )
+              uniqidC,uniqwgC,itrgtC,wedgoC, lregional_refinement, rr_factor )
 
-      use shr_kind_mod, only: r8 => shr_kind_r8
+      use shr_kind_mod, only: r8 => shr_kind_r8, i8 => shr_kind_i8
       use remap
       use reconstruct
 
       implicit none
       real(r8),           intent(in) :: weights_all(jall,nreconstruction)
       integer ,           intent(in) :: weights_eul_index_all(jall,3),weights_lgr_index_all(jall)
-      integer ,           intent(in) :: ncube,jall,nreconstruction,ntarget
+      integer ,           intent(in) :: ncube,nreconstruction,ntarget
+      integer(i8),        intent(in) :: jall
       real(r8),           intent(in) :: area_target(ntarget),target_center_lon(ntarget),target_center_lat(ntarget)
       !character(len=1024),intent(in) :: output_grid
       !logical,            intent(in) :: ldevelopment_diags
@@ -1557,6 +1609,7 @@ end subroutine THINOUT_LIST
       integer :: nswx,nrs_junk,ig,nalloc,n,ird,ThisRidge,k,nf1,nf2,IdxMin,IdxMax
       real(r8):: wt,wght
       integer,             dimension(ncube*ncube*6) :: xcoord,ycoord,pcoord
+      integer, allocatable, dimension(:)            :: pcoordMap  ! needed for stretched grid
       real(KIND=dbl_kind), dimension(ncube*ncube)   :: dA     
       real(KIND=dbl_kind), dimension(ncube,ncube,6) :: tempC
       integer,             dimension(ntarget)       :: ncells
@@ -1581,6 +1634,12 @@ end subroutine THINOUT_LIST
       CHARACTER(len=1024) :: ofile
       character(len=8)  :: date
       character(len=10) :: time
+      logical,            optional, intent(in) :: lregional_refinement
+      real(kind=dbl_kind),optional, intent(in) :: rr_factor(:,:,:)
+      real(r8), allocatable, dimension(:) :: wgtPack
+      logical :: use_rr
+
+      use_rr = present(lregional_refinement) .and. lregional_refinement
 
       CALL EquiangularAllAreas(ncube, dA)
       write(*,*) "Max target grid area   ",maxval( area_target )
@@ -1651,8 +1710,10 @@ end subroutine THINOUT_LIST
          if (npack > 0 ) then
             IdxMin  = minval(IdxPack)
             IdxMax  = maxval(IdxPack)
+            wgtPack = pack( wgt( xcoordMap, ycoordMap, pcoordMap ), (IdxOc>0) )
             do ii   = IdxMin,IdxMax
-               wght  = count( IdxPack == ii )
+               !changed to support weights for stretched grid
+               wght = sum( wgtPack, mask = (IdxPack == ii) )
                if (wght > 0) then 
                   ird=ird+1
                   MyRidges(j,ird) =  ii
@@ -1678,8 +1739,11 @@ end subroutine THINOUT_LIST
          if (npack > 0 ) then
             IdxMin  = minval(IdxPack)
             IdxMax  = maxval(IdxPack)
+            wgtPack = pack( wgt( xcoordMap, ycoordMap, pcoordMap ), (IdxOc>0) )
             do ii   = IdxMin,IdxMax
-               wght  = count( IdxPack == ii )
+               !changed to support weights for stretched grid 
+               ! orig line: wght  = count( IdxPack == ii )
+               wght = sum( wgtPack, mask = (IdxPack == ii) )
                if (wght > 0) then 
                   ird=ird+1
                   MyCrests(j,ird) =  ii
@@ -1787,7 +1851,7 @@ end subroutine THINOUT_LIST
       clext_tiles(:,:)=0._r8
 
       allocate( uniqwgMap(nalloc),uniqidMap(nalloc),xcoordMap(nalloc),ycoordMap(nalloc), &
-                wedgoMap(nalloc)  )
+                pcoordMap(nalloc),wedgoMap(nalloc)  )
 
       do j=1,ntarget
          n=NumObjects(j)
@@ -1801,6 +1865,7 @@ end subroutine THINOUT_LIST
             uniqidMap(i) = uniqidC( idxmap(i,j) )
             xcoordMap(i) = xcoord ( idxmap(i,j) )
             ycoordMap(i) = ycoord ( idxmap(i,j) )
+            pcoordMap(i) = pcoord ( idxmap(i,j) ) ! Added for stretched grid
             wedgoMap(i)  = wedgoC ( idxmap(i,j) )
          end do
          do ir=1,n
@@ -1929,8 +1994,26 @@ end subroutine THINOUT_LIST
               close(911)
 
 
-      deallocate(idxmap,idcoun,MyRidges,WtRidges,NumRidges)
+      deallocate(idxmap, idcoun, MyRidges, WtRidges, NumRidges, pcoordMap)
             write(*,*) " GOT OUT OF remapridge2tiles "
+
+    !------------------------------------------------------------------
+    contains
+      elemental real(kind=dbl_kind) function wgt(i,j,k)
+        integer, intent(in) :: i,j,k
+    
+        if ( use_rr               &
+         & .and. present(rr_factor)               &
+         & .and. i >= 1   .and. i <= size(rr_factor,1) &
+         & .and. j >= 1   .and. j <= size(rr_factor,2) &
+         & .and. k >= 1   .and. k <= size(rr_factor,3) ) then
+    
+          wgt = max( 1.0_dbl_kind, rr_factor(i,j,k) )
+        else
+          wgt = 1.0_dbl_kind
+        end if
+      end function wgt    
+      !------------------------------------------------------------------
 
   end subroutine remapridge2tiles
 !================================================================
@@ -2604,10 +2687,11 @@ function paintridge2cube ( axr, ncube,nhalo,nsw, lzerovalley, crest_length, cres
   end function paintridge2cube
  !==================================================================
 
- subroutine alloc_ridge_qs (npeaks , NSW )
+ subroutine alloc_ridge_qs (npeaks , NSW , lregional_refinement)
 
   integer, intent(in) :: npeaks
   integer, intent(in) :: NSW
+  logical, optional, intent(in) :: lregional_refinement ! needed for stretched grid
 
   allocate( xs(npeaks) )
   allocate( ys(npeaks) )
@@ -2699,6 +2783,28 @@ function paintridge2cube ( axr, ncube,nhalo,nsw, lzerovalley, crest_length, cres
   !PSW = nsw
   ! Set for ridge-finding w/ det(g) dependent window
   PSW = NINT ( 3.*nsw / 2.)
+
+  !------------------------------------------------------------------------------
+  ! CAP PSW FOR STRETCHED GRIDS:
+  ! Stretched grids (e.g., C540) can trigger excessively large PSW values,
+  ! which lead to huge temporary arrays (e.g., suba(2*PSW+1, 2*PSW+1)) being
+  ! allocated per ridge peak. This can easily blow up memory usage.
+  !
+  ! Empirically, C270 and C2160 stretched grids worked with PSW < 128.
+  ! 128 was chosen as a safe upper bound that:
+  !   - Preserves stability (avoids segfaults)
+  !   - Allows sufficient ridge detail
+  !   - Matches behavior in already working configs
+  !
+  ! This cap can be revisited if larger ridges need to be supported,
+  ! but may require additional memory tuning.
+  !------------------------------------------------------------------------------
+   IF (PRESENT(lregional_refinement)) THEN
+      IF (lregional_refinement .AND. PSW > 128) THEN
+         WRITE(*,*) "NOTE: Capping PSW for stretched grid: original =", PSW, "capped to = 128"
+         PSW = 128
+      END IF
+   END IF
 
   allocate( rdg_profiles( PSW+1, npeaks ) )
        rdg_profiles(:,:)=0.d+0

--- a/cube_to_target/ridge_ana.F90
+++ b/cube_to_target/ridge_ana.F90
@@ -462,6 +462,16 @@ write(*,*) " SHAPE ", shape( peaks%i )
 
    call alloc_ridge_qs(npeaks, NSW, lregional_refinement)
  
+   anisotropy_analysis: block
+   integer(kind=8) :: tclock1, tclock2, clock_rate
+   real(kind=8) :: elapsed_time
+   call system_clock(tclock1)
+!$omp parallel do default(none) &
+!$omp private(ipk,i,j,np,nswx,suba,subarw,subx,suby,ispk,jspk, &
+!$omp subrot) shared(npeaks,peaks,MyPanel,nsw,rdtg,do_refine, &
+!$omp rr_factor,RefFac,NSWx_diag,lregional_refinement,ncube, &
+!$omp nhalo,terr_dev_halo_r4,terr_halo_r4,xv,yv,xspk,yspk, &
+!$omp rdg_profiles_x,mxdis)
    do ipk = 1,npeaks
         i  = peaks(ipk)%i
         j  = peaks(ipk)%j
@@ -523,6 +533,10 @@ write(*,*) " SHAPE ", shape( peaks%i )
         write(*,903,advance='no') achar(13) , ipk, npeaks,nswx , mxdis(ipk)
  
    end do
+   call system_clock(tclock2, clock_rate)
+   elapsed_time = real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8)
+   print *, 'Elapsed time anisotropy analysis = ', elapsed_time, ' seconds.'
+   end block anisotropy_analysis
 
     write(*,*)
 
@@ -2260,6 +2274,10 @@ write(*,*) " in fleshout_block "
 !================================
   axc = 0.
 
+  fleshout_bloc: block
+  integer(kind=8) :: tclock1, tclock2, clock_rate
+  real(kind=8) :: elapsed_time
+  call system_clock(tclock1)
   do ip=1,6
   do j=1,ncube
   do i=1,ncube
@@ -2294,6 +2312,10 @@ write(*,*) " in fleshout_block "
   end do
   write(*,*)" finished panel=",ip
   end do
+  call system_clock(tclock2, clock_rate)
+  elapsed_time = real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8)
+  print *, 'Elapsed time fleshout block = ', elapsed_time, ' seconds.'
+  end block fleshout_bloc
 
 end function fleshout_block
 !======================================
@@ -2322,7 +2344,15 @@ function fleshout_profi ( ncube,nhalo,nsw,mxdisC,anglxC,uniqidC,rrfac,shape_x ) 
 !================================
   axc  =  0.
 
+  fleshout_prof: block
+  integer(kind=8) :: tclock1, tclock2, clock_rate
+  real(kind=8) :: elapsed_time
+  call system_clock(tclock1)
   do ip=1,6
+!$omp parallel do default(none) &
+!$omp shared(ncube,mxdisC,rrfac,uniqidC,shape_x,AXC,ip,nsw,anglxC, &
+!$omp psw,nhalo) &
+!$omp private(i,j,nswx,ipk,suba,subr,jw,rotangl,subdis,ii,jj,x0,y0)
   do j=1,ncube
   do i=1,ncube
      if(mxdisC(i,j,ip)>=1.0) then
@@ -2360,6 +2390,10 @@ function fleshout_profi ( ncube,nhalo,nsw,mxdisC,anglxC,uniqidC,rrfac,shape_x ) 
   end do
   write(*,*)" finished panel=",ip
   end do
+  call system_clock(tclock2, clock_rate)
+  elapsed_time = real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8)
+  print *, 'Elapsed time fleshout profi = ', elapsed_time, ' seconds.'
+  end block fleshout_prof
 
 end function fleshout_profi
 
@@ -2392,6 +2426,10 @@ function color_on_profi ( ncube,nhalo,nsw,mxdisC,anglxC,uniqidC,rrfac,shape_x,co
 !================================
   axc  =  0.
 
+  color_profi: block
+  integer(kind=8) :: tclock1, tclock2, clock_rate
+  real(kind=8) :: elapsed_time
+  call system_clock(tclock1)
   do ip=1,6
   do j=1,ncube
   do i=1,ncube
@@ -2440,6 +2478,10 @@ function color_on_profi ( ncube,nhalo,nsw,mxdisC,anglxC,uniqidC,rrfac,shape_x,co
   end do
   write(*,*)" finished panel=",ip
   end do
+  call system_clock(tclock2, clock_rate)
+  elapsed_time = real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8)
+  print *, 'Elapsed time color on profi = ', elapsed_time, ' seconds.'
+  end block color_profi
 
 end function color_on_profi
 
@@ -2561,7 +2603,17 @@ function paintridge2cube ( axr, ncube,nhalo,nsw, lzerovalley, crest_length, cres
 !  is selected based the closeness of the feature center (xs,ys) to
 !  its diagnosed peak-ridgecrest location (xspk,yspk)
 !=======================================================================
-  do ipk=1,npeaks
+   paintridge2cub: block
+   integer(kind=8) :: tclock1, tclock2, clock_rate
+   real(kind=8) :: elapsed_time
+   call system_clock(tclock1)
+!!!$omp parallel do ordered default(none)  &
+!!!$omp private(ipk,suba,ncl,rotangl,subr,subdis,NSWx,dsq,jj,ii,ip, &
+!!!$omp x0,y0,subq,nhw,jw,subblk0,subblk,sub1) &
+!!!$omp shared(npeaks,mxdis,Lcrestwt,clngth,nsw, &
+!!!$omp Lcrestln,anglx,axr,allpixels,xs,ys,xspk,yspk, &
+!!!$omp nhalo,ncube,QC,AXC,hwdth,sub11,RefFac,peaks)
+   do ipk=1,npeaks
         if(mxdis(ipk)>=1.0) then
  
             if(Lcrestwt) then
@@ -2693,10 +2745,14 @@ function paintridge2cube ( axr, ncube,nhalo,nsw, lzerovalley, crest_length, cres
              end do
              end do
              end if
-          end if
-      end do
+        end if
+   end do
+   call system_clock(tclock2, clock_rate)
+   elapsed_time = real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8)
+   print *, 'Elapsed time paintridge2cube = ', elapsed_time, ' seconds.'
+   end block paintridge2cub
 
-     write(*,*) " finished paintridge2cube "
+  write(*,*) " finished paintridge2cube "
      
   end function paintridge2cube
  !==================================================================

--- a/cube_to_target/rot.F90
+++ b/cube_to_target/rot.F90
@@ -263,9 +263,11 @@ end FUNCTION ROTBY3
   REAL(RPX)                           ::  AR(0:N-1,0:N-1)
 
   real(rpx) :: x(0:n-1),y(0:n-1)
-  real(rpx) :: xp(0:n-1,0:n-1),yp(0:n-1,0:n-1)
+  !real(rpx) :: xp(0:n-1,0:n-1),yp(0:n-1,0:n-1)
+  real(rpx) :: xp,yp
   real(rpx) :: r(0:n-1,0:n-1),wt(0:n-1,0:n-1)
   real(rpx) :: THETRAD,PI,swt
+  real(rpx) :: thetacos, thetasin
   integer :: i,j,l,m,n2,ii,jj,i1,j1,r00,r10,r01,r11,ic,d00
   integer :: ir,jr
 
@@ -285,22 +287,18 @@ end FUNCTION ROTBY3
      y(i)=-n2+i*1.
   end do
 
-  do j=0,n-1
-  do i=0,n-1
-     xp(i,j)=x(i)*cos(thetrad) - y(j)*sin(thetrad)
-     yp(i,j)=y(j)*cos(thetrad) + x(i)*sin(thetrad)
-  end do
-  end do
+  thetacos = cos(thetrad)
+  thetasin = sin(thetrad)
 
+  ar=-9999999.9
   do j=0,n-1
   do i=0,n-1
-     if ( (xp(i,j)<x(0)).or.(xp(i,j)>x(n-1)).or.(yp(i,j)<y(0)).or.(yp(i,j)>y(n-1)) ) then
-        ar(i,j)=-9999999.9
-     else
-     ir = NINT( xp(i,j) + n2 )
-     jr = NINT( yp(i,j) + n2 )
-          ar(i,j) = aa(ir,jr)
-     endif
+     xp=x(i)*thetacos - y(j)*thetasin
+     yp=y(j)*thetacos + x(i)*thetasin
+     if ( (xp<x(0)).or.(xp>x(n-1)).or.(yp<y(0)).or.(yp>y(n-1)) ) cycle
+     ir = NINT( xp + n2 )
+     jr = NINT( yp + n2 )
+     ar(i,j) = aa(ir,jr)
   end do
   end do
 

--- a/cube_to_target/rot.F90
+++ b/cube_to_target/rot.F90
@@ -269,6 +269,11 @@ end FUNCTION ROTBY3
   integer :: i,j,l,m,n2,ii,jj,i1,j1,r00,r10,r01,r11,ic,d00
   integer :: ir,jr
 
+  integer(kind=8) :: tclock1, tclock2, clock_rate
+  real(kind=8), save :: elapsed_time = 0.d0
+
+  call system_clock(tclock1)
+
   PI = 2*ACOS(0.0)
   THETRAD = -theta*(PI/180.)
 
@@ -298,6 +303,10 @@ end FUNCTION ROTBY3
      endif
   end do
   end do
+
+  call system_clock(tclock2, clock_rate)
+  elapsed_time = elapsed_time + (real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8))
+  print *, 'ROTBY4 = ', elapsed_time, ' seconds.'
 
 end FUNCTION ROTBY4
 

--- a/cube_to_target/rot.F90
+++ b/cube_to_target/rot.F90
@@ -271,11 +271,6 @@ end FUNCTION ROTBY3
   integer :: i,j,l,m,n2,ii,jj,i1,j1,r00,r10,r01,r11,ic,d00
   integer :: ir,jr
 
-  integer(kind=8) :: tclock1, tclock2, clock_rate
-  real(kind=8), save :: elapsed_time = 0.d0
-
-  call system_clock(tclock1)
-
   PI = 2*ACOS(0.0)
   THETRAD = -theta*(PI/180.)
 
@@ -301,10 +296,6 @@ end FUNCTION ROTBY3
      ar(i,j) = aa(ir,jr)
   end do
   end do
-
-  call system_clock(tclock2, clock_rate)
-  elapsed_time = elapsed_time + (real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8))
-  print *, 'ROTBY4 = ', elapsed_time, ' seconds.'
 
 end FUNCTION ROTBY4
 

--- a/cube_to_target/shared_vars.F90
+++ b/cube_to_target/shared_vars.F90
@@ -329,7 +329,7 @@ subroutine read_target_grid(grid_descriptor_fname,lregional_refinement,ltarget_l
   integer :: ncid,status
   integer :: ntarget_id, ncorner_id, nrank_id, nodeCount_id,nodeCoords_id,elementConn_id,numElementConn_id,centerCoords_id
   integer :: alloc_error
-  integer :: lonid, latid,nodeCount
+  integer :: lonid, latid,nodeCount, i
 
   real(r8), allocatable, dimension(:,:):: centerCoords,nodeCoords
   integer,  allocatable, dimension(:,:):: elementConn
@@ -563,9 +563,21 @@ subroutine read_target_grid(grid_descriptor_fname,lregional_refinement,ltarget_l
   status = NF_INQ_VARID(ncid, TRIM(str_area(esmf_file)), latid)
   IF (status /= NF_NOERR) CALL HANDLE_ERR(status)
   status = NF_GET_VAR_DOUBLE(ncid, latid,target_area)
+
   ! After reading target_area
   write(*,*) "target_area min/max after reading:", &
-            minval(target_area), maxval(target_area)
+             minval(target_area), maxval(target_area)
+  
+  ! Safeguard against invalid (negative or zero) areas
+  do i = 1, size(target_area)
+      if (target_area(i) <= 0.0_r8) then
+          target_area(i) = 1e-12_r8
+      endif
+  end do
+  
+  ! Confirm safeguard worked
+  write(*,*) "target_area min/max after safeguard:", &
+             minval(target_area), maxval(target_area)
 
   IF (status /= NF_NOERR) CALL HANDLE_ERR(status)
 

--- a/cube_to_target/shared_vars.F90
+++ b/cube_to_target/shared_vars.F90
@@ -313,7 +313,7 @@ end subroutine read_intermediate_cubed_sphere_grid
 
 
 subroutine read_target_grid(grid_descriptor_fname,lregional_refinement,ltarget_latlon,lpole,nlat,nlon,ntarget,ncorner,nrank,&
-     target_corner_lon, target_corner_lat, target_center_lon, target_center_lat, target_area, target_rrfac)
+     target_corner_lon, target_corner_lat, target_center_lon, target_center_lat, target_area, target_rrfac, grid_fallback_mask)
   implicit none
 #     include         <netcdf.inc>
   character(len=1024), intent(in) :: grid_descriptor_fname
@@ -323,6 +323,7 @@ subroutine read_target_grid(grid_descriptor_fname,lregional_refinement,ltarget_l
   real(r8), allocatable, dimension(:,:), intent(out) :: target_corner_lon, target_corner_lat
   real(r8), allocatable, dimension(:)  , intent(out) :: target_center_lon, target_center_lat, target_area
   real(r8), allocatable, dimension(:)  , intent(out) :: target_rrfac
+  integer , allocatable, dimension(:)  , intent(out) :: grid_fallback_mask
 
 
   integer :: ncid,status
@@ -341,6 +342,7 @@ subroutine read_target_grid(grid_descriptor_fname,lregional_refinement,ltarget_l
   integer            :: esmf_file = 1 ! =1 SCRIP naming convention; =2 ESMF naming convention
   integer            :: icorner,icell,num
   integer            :: grid_dims(2)
+
 
   ltarget_latlon = .FALSE.
   !
@@ -495,16 +497,39 @@ subroutine read_target_grid(grid_descriptor_fname,lregional_refinement,ltarget_l
 
     IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR(STATUS)
     IF (maxval(target_corner_lat)>10.0) target_corner_lat = deg2rad*target_corner_lat    
+
+    ! Immediately after reading from netCDF
+    write(*,*) "Verifying target_corner_lon/lat loaded from file"
+    do icell = 1, ntarget
+        if (all(target_corner_lon(:,icell) == 0.0_r8) .and. all(target_corner_lat(:,icell) == 0.0_r8)) then
+            write(*,*) "CRITICAL ERROR: Cell corners all zero at index", icell
+            stop "Failed netCDF load"
+        endif
+    enddo
+    
     !
     ! for writing remapped data on file at the end of the program
     !    
     status = NF_INQ_VARID(ncid, 'grid_center_lon', lonid)
+    if (status /= NF_NOERR) CALL HANDLE_ERR(status)
     status = NF_GET_VAR_DOUBLE(ncid, lonid,target_center_lon)
+    IF (status /= NF_NOERR) CALL HANDLE_ERR(status)
     IF (maxval(target_center_lon)>10.0) target_center_lon = deg2rad*target_center_lon    
-    
+
     status = NF_INQ_VARID(ncid, 'grid_center_lat', latid)
+    if (status /= NF_NOERR) CALL HANDLE_ERR(status)
     status = NF_GET_VAR_DOUBLE(ncid, latid,target_center_lat)
+    IF (status /= NF_NOERR) CALL HANDLE_ERR(status)
     IF (maxval(target_center_lat)>10.0) target_center_lat = deg2rad*target_center_lat    
+
+    ! Immediately after reading center coordinates
+    write(*,*) "Diagnostic check for target_center_lon/lat:"
+    do icell = 1, min(5, ntarget)
+        write(*,*) "Cell:", icell, &
+            " Lon:", target_center_lon(icell), &
+            " Lat:", target_center_lat(icell)
+    enddo    
+    
     if (ltarget_latlon) then
       if (maxval(target_center_lat)>pih-1E-5) then
         lpole=.true.
@@ -529,14 +554,49 @@ subroutine read_target_grid(grid_descriptor_fname,lregional_refinement,ltarget_l
   else
     lregional_refinement = .true.
     allocate ( target_rrfac(ntarget),stat=alloc_error)
+    IF (alloc_error /= 0) STOP "Allocation failed for target_rrfac"
     status = NF_GET_VAR_DOUBLE(ncid, rrfacid,target_rrfac)
     IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR(STATUS)
     write(*,*) "rrfac on file; setting lregional_refinement = .true."
   end if
 
   status = NF_INQ_VARID(ncid, TRIM(str_area(esmf_file)), latid)
+  IF (status /= NF_NOERR) CALL HANDLE_ERR(status)
   status = NF_GET_VAR_DOUBLE(ncid, latid,target_area)
-  
+  ! After reading target_area
+  write(*,*) "target_area min/max after reading:", &
+            minval(target_area), maxval(target_area)
+
+  IF (status /= NF_NOERR) CALL HANDLE_ERR(status)
+
+  !---------------------------------------------------------------------------
+  ! Read fallback mask from target grid NetCDF descriptor.
+  !
+  ! This mask (grid_fallback_mask) identifies cells where the remapping
+  ! geometry is invalid (e.g., zero or negative area in SCRIP grid). These
+  ! cells are treated with special fallback logic during terrain assignment.
+  !
+  ! The mask is used downstream to avoid using unreliable terrain values
+  ! and to fill affected cells with nearby valid terrain, ensuring smoother,
+  ! more physically consistent elevation fields especially in stretched grids.
+  !---------------------------------------------------------------------------    
+  allocate(grid_fallback_mask(ntarget), stat=alloc_error)
+  if (alloc_error /= 0) stop "Allocation failed for grid_fallback_mask"
+
+  status = NF_INQ_VARID(ncid, 'grid_fallback_mask', latid)
+  if (status == NF_NOERR) then
+     status = NF_GET_VAR_INT(ncid, latid, grid_fallback_mask)
+     if (status /= NF_NOERR) call handle_err(status)
+  else
+    write(*,*) "grid_fallback_mask not found; initializing to 0"
+    grid_fallback_mask = 0
+  end if
+
+ ! Diagnostic print for grid_fallback_mask
+  write(*,*) "grid_fallback_mask min/max after reading:", &
+            minval(grid_fallback_mask), maxval(grid_fallback_mask), &
+            " total fallback cells:", count(grid_fallback_mask == 1) 
+
   status = nf_close (ncid)
   if (status .ne. NF_NOERR) call handle_err(status)          
   end subroutine read_target_grid

--- a/cube_to_target/smooth_topo_cube.F90
+++ b/cube_to_target/smooth_topo_cube.F90
@@ -64,7 +64,7 @@ CONTAINS
     integer, INTENT(IN)  :: rrfac_max
 
     real(r8), DIMENSION(1-nhalo:ncube+nhalo, 1-nhalo:ncube+nhalo, 6) :: terr_halo
-    real(r8), DIMENSION(1-nhalo:ncube+nhalo, 1-nhalo:ncube+nhalo, 6) :: terr_halo_sm, terr_halo_dev
+    real(r8), DIMENSION(1-nhalo:ncube+nhalo, 1-nhalo:ncube+nhalo, 6) :: terr_halo_sm 
     real(r8), DIMENSION(1-nhalo:ncube+nhalo, 1-nhalo:ncube+nhalo, 6) :: da_halo, rr_halo, rr_halo_sm
     real(r8), DIMENSION(ncube,ncube,6)                               :: daxx, rrfac_sm, lap
     real(r8), allocatable :: terr_sm00(:,:,:), terr_dev00(:,:,:), rr_updt(:,:,:)  !needed for stretched grid - do_schmidt
@@ -72,15 +72,15 @@ CONTAINS
 
     real(r8), DIMENSION(ncube,ncube,6) :: landfrac_local
 
-    integer  :: ncubex, nhalox,NSCL_fx,NSCL_cx,ip
+    integer  :: ip
     real(r8) :: volterr_in,volterr_sm
      
 
-    integer  :: ncube_in_file, iter,i,j
+    integer  :: iter,i,j
 
 
     logical ::     read_in_precomputed, use_prefilter, stop_after_smoothing
-    logical ::     smooth_topo_cubesph, do_refine
+    logical ::     smooth_topo_cubesph 
     logical ::     read_in_and_refine, new_smooth_topo
 
     logical             :: do_schmidt                             ! needed for stretched grid - do_schmidt
@@ -534,14 +534,12 @@ CONTAINS
     real(r8), dimension(0:ncube+1,0:ncube+1)   :: ggaa, ggbb, ggab, ggba, sqgg !metric terms cell centers
     real(r8), dimension(0:ncube+1,0:ncube+1)   :: ggaa_e, ggbb_e, ggab_e, ggba_e, sqgg_e!metric terms edge
     real(r8), dimension(1-nhalo:ncube+nhalo,1-nhalo:ncube+nhalo,6) :: terr_halo
-    real(r8), dimension(0:ncube+2,0:ncube+2)   :: terr_halo_edgeX, terr_halo_edgeY
     real(r8)                                                       :: alph, beta
     real(r8)                                                       :: da,irho,irhosq,piq,pi
     real(r8)                                                       :: inv_da,factor
     real(r8)                                                       :: lap_x,lap_y,lap_xy,lap_yx
 
 
-    real(r8), dimension(0:ncube+2,0:ncube+2) :: xterm, yterm, xterm_edgeX, xterm_edgeY
     real(r8) :: aa,bb,cc,dd,det
 #ifdef idealized_test
     real(r8), dimension(ncube,ncube,6)  :: exact
@@ -675,7 +673,7 @@ end subroutine laplacian
     real(r8), intent(out) :: lap_psi(ncube,ncube,6)
     integer, intent(in)   :: ncube
 
-    real(r8) :: piq,da,alpha,beta,lon,lat,psi,grad_lat,grad_lon,xterm,yterm
+    real(r8) :: piq,da,alpha,beta,lon,lat,psi,grad_lon
     integer  :: i,j,ip
     piq = DATAN(1.D0)
     da = 2.0_r8*piq/DBLE(ncube)
@@ -715,21 +713,17 @@ end subroutine laplacian
     !Internal work arrays
     !-----------------------------------------------------------------
     !------------------------------
-    real(r8), DIMENSION(1-nhalo:ncube+nhalo, 1-nhalo:ncube+nhalo):: smwt,ggaa,ggbb,ggab
+    real(r8), DIMENSION(1-nhalo:ncube+nhalo, 1-nhalo:ncube+nhalo):: ggaa,ggbb,ggab
     real(r8), DIMENSION(1-nhalo:ncube+nhalo )                    :: xv,yv,alph,beta
 
-    integer:: np,i,j, ncube_halo,norx,nory,ipanel,x0,&
-         x1,y0,y1,initd,ii0,ii1,jj0,jj1,nctest,NSM,NS2,ismi,NSB,ns2x
-
+    integer:: np,i,j, ncube_halo,norx,NSM,NS2,ns2x
 
     real(r8), allocatable ::  wt1p(:,:),terr_patch(:,:)
-    real(r8)  :: cosll, dx, dy ,dbet,dalp,diss,diss00,lon_ij,lat_ij,latfactor,diss0r
+    real(r8)  ::  dbet,dalp,diss,diss00,diss0r
 
-    INTEGER :: NOCTV , isx0, isx1, jsy0, jsy1,i2,j2,iix,jjx,i00,ncube_in_file
+    INTEGER :: NOCTV ,jsy0, i2,j2,iix,jjx,i00
 
-    real(r8) :: RSM_scl, smoo,irho,volt0,volt1,volume_after,volume_before,wt1ps,diss0e
-
-    CHARACTER(len=1024) :: ofile
+    real(r8) :: RSM_scl, smoo,irho,wt1ps,diss0e
 
     LOGICAL :: do_smooth_ij
 
@@ -974,7 +968,6 @@ subroutine wrtncdf_topo_smooth_data(ncube,n,terr_sm,terr_dev,landfrac,output_fna
   integer, dimension(2) :: nid
     
   real(r8), parameter :: fillvalue = 1.d36
-  integer, dimension(1) :: latdim
   character(len=1024) :: str
   real(r8)            :: pi,piq,da,alph,beta,lon(ncube,ncube,6),lat(ncube,ncube,6)
   integer             :: i,j,ip
@@ -1145,7 +1138,7 @@ subroutine read_topo_smooth_data(fname,ncol,terr_sm,terr_dev,rr_fac)
   real(r8),dimension(ncol), intent(out) :: terr_sm,terr_dev
   real(r8),dimension(ncol), intent(out), optional :: rr_fac
 
-  integer :: ncid,status, dimid, alloc_error, terr_sm_id,terr_dev_id,ncol_file, rr_fac_id
+  integer :: ncid,status, dimid, terr_sm_id,terr_dev_id,ncol_file, rr_fac_id
 
   status = nf_open(TRIM(fname) , 0, ncid)
   IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR(STATUS)

--- a/cube_to_target/smooth_topo_cube.F90
+++ b/cube_to_target/smooth_topo_cube.F90
@@ -56,7 +56,8 @@ CONTAINS
     real(r8), intent(in)             :: nu_lap
     integer, intent(in)                          :: smooth_phis_numcycle
     real(r8), DIMENSION(ncube,ncube,6), INTENT(IN) :: landfrac
-    logical, intent(in)                          :: lsmoothing_over_ocean, lsmooth_rrfac
+    logical, intent(in)                          :: lsmoothing_over_ocean
+    logical, intent(inout)                       :: lsmooth_rrfac          ! may be updated for stretched grid
     CHARACTER(len=1024), INTENT(IN   ), optional :: smooth_topo_fname
 
 
@@ -66,7 +67,8 @@ CONTAINS
     real(r8), DIMENSION(1-nhalo:ncube+nhalo, 1-nhalo:ncube+nhalo, 6) :: terr_halo_sm, terr_halo_dev
     real(r8), DIMENSION(1-nhalo:ncube+nhalo, 1-nhalo:ncube+nhalo, 6) :: da_halo, rr_halo, rr_halo_sm
     real(r8), DIMENSION(ncube,ncube,6)                               :: daxx, rrfac_sm, lap
-    real(r8), DIMENSION(ncube, ncube, 6)                             :: terr_sm00,terr_dev00,rr_updt
+    real(r8), allocatable :: terr_sm00(:,:,:), terr_dev00(:,:,:), rr_updt(:,:,:)  !needed for stretched grid - do_schmidt
+    real(r8), allocatable :: terr_orig(:,:,:)                                     !needed for stretched grid - do_schmidt
 
     real(r8), DIMENSION(ncube,ncube,6) :: landfrac_local
 
@@ -81,10 +83,22 @@ CONTAINS
     logical ::     smooth_topo_cubesph, do_refine
     logical ::     read_in_and_refine, new_smooth_topo
 
+    logical             :: do_schmidt                             ! needed for stretched grid - do_schmidt
+    real(r8)            :: target_lon, target_lat, stretch_factor ! needed for stretched grid - do_schmidt
+    real(r8)            :: base_dt, alpha                         ! needed for stretched grid - do_schmidt
+
     real(r8), parameter :: rearth = 6.37122e6 !radius of Earth from CIME/CESM
     real(r8)            :: nu_lap_unit_sphere,dt
     real(r8)            :: min_terr, max_terr   !to check if Laplacian smoother is stable
     real(r8)            :: min_rrfac, max_rrfac !to check if Laplacian smoother is stable
+
+    ! If caller forgot to set the flag, infer it from rrfac & refinement
+    if (.not. lsmooth_rrfac) then   
+       if (lregional_refinement .and. ANY(rrfac > 0._r8)) then
+          lsmooth_rrfac = .true. 
+       end if
+    end if
+
     !read_in_precomputed = .FALSE.
     read_in_precomputed = lread_smooth_topofile  !.TRUE.
     use_prefilter = luse_prefilter 
@@ -95,25 +109,22 @@ CONTAINS
     IF (read_in_precomputed) then
       write(*,*) " Read precomputed filtered topography from ",trim(smooth_topo_fname)
       if (lregional_refinement) then
-!check can not overwrite rrfac - I think we need merge from Julio
-        !        call read_topo_smooth_data(smooth_topo_fname,ncube*ncube*6,terr_sm,terr_dev,rr_fac=rrfac)
         call read_topo_smooth_data(smooth_topo_fname,ncube*ncube*6,terr_sm,terr_dev)
       else
         call read_topo_smooth_data(smooth_topo_fname,ncube*ncube*6,terr_sm,terr_dev)
       end if
       ! return to main program after
       ! reading topography variables
-      if (.NOT. lregional_refinement) then 
-        RETURN
+
+      ! Handle refinement-specific memory capture
+      if (read_in_and_refine .and. lregional_refinement) then
+          terr_sm00  = terr_sm
+          terr_dev00 = terr_dev
       else
-        read_in_and_refine=.TRUE.
-      end if   
-      terr_sm00  = terr_sm
-      terr_dev00 = terr_dev
-    ELSE
-      terr_sm00  = 0.
-      terr_dev00 = 0.
-    ENDIF
+          terr_sm00  = terr
+          terr_dev00 = 0.0_r8
+      end if
+    END IF   ! close read_in_precomputed  
 
      ! If your are here and read_in_and_refine=.FALSE. then
      ! then you must want to generate a new smooth topo.  So 
@@ -122,6 +133,18 @@ CONTAINS
      ! is more readable if done here and passed in.
      !---------------------------------------
      new_smooth_topo = .NOT.(read_in_and_refine)
+     ! Ensure arrays are allocated and initialized consistently
+     if (.not. allocated(terr_orig))  allocate(terr_orig(ncube, ncube, 6))
+     terr_orig = terr
+     
+     if (.not. allocated(terr_sm00))  allocate(terr_sm00(ncube, ncube, 6))
+     terr_sm00  = terr
+     
+     if (.not. allocated(terr_dev00)) allocate(terr_dev00(ncube, ncube, 6))
+     terr_dev00 = 0.0_r8
+     
+     if (.not. allocated(rr_updt)) allocate(rr_updt(ncube, ncube, 6))
+     rr_updt = 0.0_r8
 
      if ( ldevelopment_diags.AND.(NSCL_f>0) ) then
        write( ofname , &
@@ -134,7 +157,7 @@ CONTAINS
             ncube, NSCL_c/2
        ofname = 'topo_smooth_'//trim(str_source)//trim(ofname)
      end if
-     
+
      if (lregional_refinement) then
        ofname= TRIM(str_dir)//'/'//trim(ofname)//'_'//trim(ogrid)//'.nc'
      else
@@ -210,6 +233,13 @@ CONTAINS
          !
          nu_lap_unit_sphere = nu_lap/(rearth*rearth)
 
+        ! If caller forgot to set the flag, infer it from rrfac & refinement
+        if (.not. lsmooth_rrfac) then
+           if (lregional_refinement .and. ANY(rrfac > 0._r8)) then
+              lsmooth_rrfac = .true.
+           end if
+        end if
+
          if (lregional_refinement.and.lsmooth_rrfac) then
            write(*,*) "Smoooth rrfac"
            max_rrfac = MAXVAL(rrfac)
@@ -243,25 +273,131 @@ CONTAINS
              end do
            end do
          end if
-         !
-         ! smooth surface height
-         !
-         write(*,*) "Smoooth height"
-         rrfac_sm = (1.0/rrfac)**2 !scaling of smoothing coefficient
-         max_terr = MAXVAL(terr)
-         min_terr = MINVAL(terr)
-         terr_sm = terr
-         dt = 16.0/real(smooth_phis_numcycle)
-         do iter = 1,smooth_phis_numcycle
-           call progress_bar("# ", iter, DBLE(100*iter)/DBLE(smooth_phis_numcycle))
-           call laplacian(terr_sm, ncube, lap, landfrac_local,lsmoothing_over_ocean)
-           terr_sm = terr_sm+lap*dt*nu_lap_unit_sphere*rrfac_sm
-           if (MAXVAL(terr_sm)>1.2*max_terr.or.MINVAL(terr_sm)<min_terr-500.0) then
-             write(*,*) "Laplace iteration seems to be unstable: MINVAL(terr_sm),MAXVAL(terr_sm)",MINVAL(terr_sm),MAXVAL(terr_sm)
-             stop
-           end if
-         end do
-       endif
+
+         ! Stretch-grid control (YAML may say DO_SCHMIDT: true/false)
+         call read_gen_scrip('GenScrip.yaml', do_schmidt, target_lon, target_lat, stretch_factor)
+
+       !---------------------------------------------------------------------------------------
+       !  Surface-height smoothing
+       !  • Uniform / PE grids   → original Laplacian loop
+       !  • Schmidt stretched    → CFL-scaled loop 
+       !========================================================================================
+       ! WHY THE “SCHMIDT-STRETCHED” HEIGHT SMOOTHER LOOKS DIFFERENT
+       ! ---------------------------------------------------------------------------------------
+       !   On a refined Schmidt grid (“regional-refinement” / RRFAC>1) the smallest
+       !    cube-sphere cells can be Δx ≈ (1/RRFAC) times the coarse-grid spacing.
+       !    If we ran the same Laplacian diffusion with a coarse-grid time-step,
+       !    ∆t/∆x² would violate the CFL limit and the height field would blow up
+       !    after a few iterations.
+       !
+       !   We therefore:
+       !      – Scale a *local* stability factor  rrfac_sm = (1/rrfac)²  .
+       !        Where the grid is 4 × finer (rrfac=4) we multiply the diffusion
+       !        coefficient by (1/4)² = 1/16, so the effective ∆t/∆x² matches the
+       !        coarse region.
+       !
+       !      – Reduce the base time-step:
+       !            base_dt = 16 / smooth_phis_numcycle         (regular-grid value)
+       !            dt      = base_dt / (stretch_factor*4)      (extra safety for zoom)
+       !
+       !        `stretch_factor` is the Schmidt refinement factor n.
+       !            Local grid spacing = coarse-grid spacing / n
+       !            Effective resolution = C_base × n
+       !               examples:  (C-equivalent values are illustrative; any n≥1 works.)
+       !                   C270  with n = 2.5   → local ≈ C675
+       !                   C540  with n = 2.5   → local ≈ C1350
+       !                   C1539 with n = 3.0   → local ≈ C4617
+       !        The extra “×4” in  dt = base_dt / (n*4)  is a universal safety
+       !        margin so the smallest refined cell stays within the global CFL
+       !        limit, independent of the exact value of n.
+       !
+       !      – Limit each update with an empirical α = 0.3 to damp the first
+       !        iteration spike that can appear at sharp terrain steps.
+       !
+       !   The guard:
+       !        if (.not. any(rrfac > 0.)) then
+       !            … skip smoother …
+       !        endif
+       !    allows the exact same subroutine to run on a regular grid where
+       !    rr_factor==1 everywhere (the new maths collapses to the old one).
+       !
+       !   Runtime sanity-check:
+       !        MAXVAL(terr_sm) > 1.2*MAX(terr)  OR  MINVAL(terr_sm) < MIN(terr)-500 m
+       !    catches a divergence early and aborts with a clear message instead
+       !    of corrupting the topo file.
+       !
+       ! Short version: all extra factors keep ∆t/∆x² locally the same as the
+       ! coarse grid, so stretched runs are stable while regular runs remain
+       ! bit-for-bit identical to the historical smoother.
+       !========================================================================================
+         
+         if (.not. do_schmidt) then
+            !––– ORIGINAL UNIFORM SMOOTHER ––––––––––––––––––––––––––––
+            write(*,*) "Smooth height (uniform)"
+            rrfac_sm = (1.0_r8/rrfac)**2
+            max_terr = MAXVAL(terr);  min_terr = MINVAL(terr)
+            terr_sm  = terr
+            dt       = 16.0_r8 / REAL(smooth_phis_numcycle, r8)
+         
+            do iter = 1, smooth_phis_numcycle
+               call progress_bar("# ", iter, 100.0_r8*iter/smooth_phis_numcycle)
+               call laplacian(terr_sm, ncube, lap, landfrac_local, lsmoothing_over_ocean)
+               terr_sm = terr_sm + lap*dt*nu_lap_unit_sphere*rrfac_sm
+         
+               if (MAXVAL(terr_sm) > 1.2_r8*max_terr .or. MINVAL(terr_sm) < min_terr-500._r8) then
+                  write(*,*) "Laplace iteration seems to be unstable:"
+                  write(*,*) "MIN, MAX(terr_sm) =", MINVAL(terr_sm), MAXVAL(terr_sm)
+                  stop
+               end if
+            end do
+         
+         else
+            !––– SCHMIDT-STRETCHED SMOOTHER –––––––––––––––––––––––––––
+            write(*,*) "Smooth height (stretched)"
+         
+            if (.not. any(rrfac > 0._r8)) then
+               write(*,*) "INFO: no RRFAC present – skipping height smoother"
+               terr_sm = terr
+            else
+               terr_sm  = terr
+               rrfac_sm = (1.0_r8/rrfac)**2
+         
+               max_terr = MAXVAL(terr);  min_terr = MINVAL(terr)
+               base_dt  = 16.0_r8 / REAL(smooth_phis_numcycle, r8)
+               dt       = base_dt / (stretch_factor*4.0_r8)   ! tighter CFL for stretched
+               alpha    = 0.3_r8                              ! optional limiter
+         
+               do iter = 1, smooth_phis_numcycle
+                  call progress_bar("# ", iter, 100.0_r8*iter/smooth_phis_numcycle)
+                  call laplacian(terr_sm, ncube, lap, landfrac, lsmoothing_over_ocean)
+                  terr_sm = terr_sm + alpha*(lap*dt*nu_lap_unit_sphere*rrfac_sm)
+         
+                  if (MAXVAL(terr_sm) > 1.2_r8*max_terr .or. MINVAL(terr_sm) < min_terr-500._r8) then
+                     write(*,*) "ERROR: height blow-up at iter=", iter
+                     stop
+                  end if
+               end do
+            end if
+         end if ! <– closes “if (.not. do_schmidt)”
+       endif    ! <- closes "IF (ldistance_weighted_smoother)"
+!====================================================================
+! >>> be sure refined cap is merged with coarse halo <<<
+!====================================================================
+         ! Any cell whose r‑factor update is > 1 belongs to the refined cap.
+         ! Copy refined topo over the pre‑existing coarse field.
+         ! build mask once, independent of smoother branch
+      if (lregional_refinement) rr_updt = rrfac 
+
+      if (lregional_refinement) then
+         write(*,*) "Sanity check: MIN/MAX(rr_updt) =", MINVAL(rr_updt), MAXVAL(rr_updt)
+      end if
+
+      if (read_in_and_refine .and. lregional_refinement) then
+         terr_sm  = merge(terr_sm ,  terr_sm00, rr_updt > 1.0_r8)
+         terr_dev = merge(terr_dev, terr_dev00, rr_updt > 1.0_r8)
+      end if
+!--------------------------------------------------------------------
+
       volterr_in=0.
       volterr_sm=0.
       do ip=1,6 
@@ -279,7 +415,14 @@ CONTAINS
       end do
       write(*,*) " Smooth Topo volume  AFTER rescaling = ",volterr_sm/(6*sum(da))
 
-      terr_dev = terr - terr_sm
+      ! Sanity check allocations and array sizes before computing terr_dev
+      write(*,*) "Checking arrays before terr_dev calculation:"
+      write(*,*) "terr_orig allocated:", allocated(terr_orig), "shape:", shape(terr_orig)
+      write(*,*) "terr_sm shape:", shape(terr_sm)
+      write(*,*) "terr_dev shape:", shape(terr_dev)      
+      
+      ! Now do the subtraction
+      terr_dev = terr_orig - terr_sm
 
       if (read_in_and_refine) then
         where( rr_updt <= 1. )
@@ -298,7 +441,76 @@ CONTAINS
         end if
         if (stop_after_smoothing ) STOP
       end if
+
+      ! Clean up
+      if (allocated(terr_orig))     deallocate(terr_orig)
+      if (allocated(terr_sm00))     deallocate(terr_sm00)
+      if (allocated(terr_dev00))    deallocate(terr_dev00)
+      if (allocated(rr_updt))       deallocate(rr_updt)
+
   end SUBROUTINE smooth_intermediate_topo_wrap
+
+ !-------------------------------------------------------------------
+ ! read_gen_scrip
+ !   Reads four key/value lines from GenScrip.yaml:
+ !     DO_SCHMIDT, TARGET_LON, TARGET_LAT, STRETCH_FACTOR
+ !   Returns them through the intent-out arguments.
+ !   If the file can’t be opened the routine simply returns with
+ !   default values (no Schmidt stretching).
+ !-------------------------------------------------------------------
+
+  subroutine read_gen_scrip(  cfgFile   , do_schmidt  , target_lon , target_lat    , stretch_factor )
+    implicit none
+  
+    !-- arguments
+    character(len=*), intent(in ) :: cfgFile
+    logical        , intent(out) :: do_schmidt
+    real(r8)       , intent(out) :: target_lon, target_lat, stretch_factor
+  
+    !-- locals
+    integer              :: ios, unit, idx
+    character(len=256)   :: line, valstr
+    character(len=32)    :: key
+      
+    !-- defaults
+    do_schmidt     = .false.
+    target_lon     =  0.0_r8 
+    target_lat     =  0.0_r8
+    stretch_factor =  1.0_r8
+            
+    open(newunit=unit, file=cfgFile, status='old', action='read', iostat=ios)
+    if (ios /= 0) then 
+      write(*,*) 'WARNING: Could not open ', trim(cfgFile), ' – assuming no stretching.'
+      return
+    endif
+            
+    do      
+      read(unit, '(A)', iostat=ios) line
+      if (ios /= 0) exit    ! EOF or error
+
+      ! find the colon
+      idx = index(line, ':')
+      if (idx == 0) cycle   ! no “:” on this line
+               
+      ! split key vs. value
+      key   = adjustl( line(:idx-1) )
+      valstr= adjustl( line(idx+1:) ) 
+                  
+      select case(trim(key))
+      case('DO_SCHMIDT')
+        do_schmidt = .true.
+      case('TARGET_LON')
+        read(valstr, *) target_lon
+      case('TARGET_LAT')
+        read(valstr, *) target_lat
+      case('STRETCH_FACTOR')
+        read(valstr, *) stretch_factor 
+      end select
+    end do   
+         
+    close(unit)
+  end subroutine read_gen_scrip
+
 
   subroutine laplacian(terr, ncube, lap, landfrac, lsmoothing_over_ocean)
     real(r8), dimension(ncube,ncube,6), intent(in)  :: terr

--- a/cube_to_target/smooth_topo_cube.F90
+++ b/cube_to_target/smooth_topo_cube.F90
@@ -338,6 +338,10 @@ CONTAINS
             terr_sm  = terr
             dt       = 16.0_r8 / REAL(smooth_phis_numcycle, r8)
          
+      smooth_phis_cycle: block
+      integer(kind=8) :: tclock1, tclock2, clock_rate
+      real(kind=8) :: elapsed_time
+      call system_clock(tclock1)
             do iter = 1, smooth_phis_numcycle
                call progress_bar("# ", iter, 100.0_r8*iter/smooth_phis_numcycle)
                call laplacian(terr_sm, ncube, lap, landfrac_local, lsmoothing_over_ocean)
@@ -349,6 +353,10 @@ CONTAINS
                   stop
                end if
             end do
+      call system_clock(tclock2, clock_rate)
+      elapsed_time = real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8)
+      print *, 'Elapsed time smooth_phis_cycle smooth_topo_cube = ', elapsed_time, ' seconds.'
+      end block smooth_phis_cycle
          
          else
             !––– SCHMIDT-STRETCHED SMOOTHER –––––––––––––––––––––––––––
@@ -566,6 +574,9 @@ CONTAINS
     !
     ! remember to use inverse metric!
     !
+!$omp parallel do default(none) &
+!$omp shared(ncube,piq,da,sqgg,ggaa,ggab,ggba,ggbb) &
+!$omp private(i,j,alph,beta,irhosq,irho,factor,aa,dd,bb,cc,det)
     DO j=0,ncube+1
       DO i=0,ncube+1
         alph = -piq+(DBLE(i)-0.5)*da
@@ -595,6 +606,9 @@ CONTAINS
     !
     ! Same as above but for edge of cells
     !
+!$omp parallel do default(none) &
+!$omp shared(ncube,piq,da,sqgg_e,ggaa_e,ggab_e,ggba_e,ggbb_e) &
+!$omp private(i,j,alph,beta,irhosq,irho,factor,aa,dd,bb,cc,det)
     DO j=0,ncube+1
       DO i=0,ncube+1
         alph = -piq+DBLE((i-1))*da
@@ -622,6 +636,8 @@ CONTAINS
       END DO
     END DO
 
+!$omp parallel do default(none) &
+!$omp private(ip) shared(terr,terr_halo,ncube)
     do ip=1,6
       call CubedSphereFillHalo_Cubic(terr, terr_halo, ip, ncube+1)
     end do
@@ -634,6 +650,10 @@ CONTAINS
     ! Nair, MWR, 2009
     !
     do ip=1,6
+!$omp parallel do default(none) &
+!$omp shared(ip,lap,landfrac_local,terr_halo,sqgg_e, &
+!$omp ggaa_e,ggbb_e,ggab,ggba,inv_da,sqgg,ncube) &
+!$omp private(i,j,lap_x,lap_xy,lap_y,lap_yx) 
       do j=1,ncube
         do i=1,ncube
           if (landfrac_local(i,j,ip) > 0.0_r8) then

--- a/cube_to_target/smooth_topo_cube.F90
+++ b/cube_to_target/smooth_topo_cube.F90
@@ -574,9 +574,6 @@ CONTAINS
     !
     ! remember to use inverse metric!
     !
-!$omp parallel do default(none) &
-!$omp shared(ncube,piq,da,sqgg,ggaa,ggab,ggba,ggbb) &
-!$omp private(i,j,alph,beta,irhosq,irho,factor,aa,dd,bb,cc,det)
     DO j=0,ncube+1
       DO i=0,ncube+1
         alph = -piq+(DBLE(i)-0.5)*da
@@ -606,9 +603,6 @@ CONTAINS
     !
     ! Same as above but for edge of cells
     !
-!$omp parallel do default(none) &
-!$omp shared(ncube,piq,da,sqgg_e,ggaa_e,ggab_e,ggba_e,ggbb_e) &
-!$omp private(i,j,alph,beta,irhosq,irho,factor,aa,dd,bb,cc,det)
     DO j=0,ncube+1
       DO i=0,ncube+1
         alph = -piq+DBLE((i-1))*da
@@ -636,8 +630,6 @@ CONTAINS
       END DO
     END DO
 
-!$omp parallel do default(none) &
-!$omp private(ip) shared(terr,terr_halo,ncube)
     do ip=1,6
       call CubedSphereFillHalo_Cubic(terr, terr_halo, ip, ncube+1)
     end do
@@ -650,10 +642,6 @@ CONTAINS
     ! Nair, MWR, 2009
     !
     do ip=1,6
-!$omp parallel do default(none) &
-!$omp shared(ip,lap,landfrac_local,terr_halo,sqgg_e, &
-!$omp ggaa_e,ggbb_e,ggab,ggba,inv_da,sqgg,ncube) &
-!$omp private(i,j,lap_x,lap_xy,lap_y,lap_yx) 
       do j=1,ncube
         do i=1,ncube
           if (landfrac_local(i,j,ip) > 0.0_r8) then

--- a/cube_to_target/smooth_topo_cube.F90
+++ b/cube_to_target/smooth_topo_cube.F90
@@ -101,30 +101,23 @@ CONTAINS
 
     !read_in_precomputed = .FALSE.
     read_in_precomputed = lread_smooth_topofile  !.TRUE.
+    read_in_and_refine = lread_smooth_topofile .and. lregional_refinement
     use_prefilter = luse_prefilter 
     stop_after_smoothing = lstop_after_smoothing 
     smooth_topo_cubesph = .TRUE.  
-    read_in_and_refine=.FALSE.
+
+    write(*,*) "DEBUG: read_in_and_refine =", read_in_and_refine
 
     IF (read_in_precomputed) then
-      write(*,*) " Read precomputed filtered topography from ",trim(smooth_topo_fname)
-      if (lregional_refinement) then
-        call read_topo_smooth_data(smooth_topo_fname,ncube*ncube*6,terr_sm,terr_dev)
-      else
-        call read_topo_smooth_data(smooth_topo_fname,ncube*ncube*6,terr_sm,terr_dev)
-      end if
-      ! return to main program after
-      ! reading topography variables
-
-      ! Handle refinement-specific memory capture
-      if (read_in_and_refine .and. lregional_refinement) then
-          terr_sm00  = terr_sm
-          terr_dev00 = terr_dev
-      else
-          terr_sm00  = terr
-          terr_dev00 = 0.0_r8
-      end if
-    END IF   ! close read_in_precomputed  
+       write(*,*) " Read precomputed filtered topography from ",trim(smooth_topo_fname)
+       call read_topo_smooth_data(smooth_topo_fname,ncube*ncube*6,terr_sm,terr_dev)
+    
+       if (.NOT. lregional_refinement) RETURN  ! explicitly preserve original early-return logic
+    
+       ! Proceed only if refinement is requested
+       terr_sm00  = terr_sm
+       terr_dev00 = terr_dev
+    END IF
 
      ! If your are here and read_in_and_refine=.FALSE. then
      ! then you must want to generate a new smooth topo.  So 
@@ -330,7 +323,13 @@ CONTAINS
        ! coarse grid, so stretched runs are stable while regular runs remain
        ! bit-for-bit identical to the historical smoother.
        !========================================================================================
-         
+       write(*,*) "Before smoothing checks:"
+       write(*,*) "terr min/max:", MINVAL(terr), MAXVAL(terr)
+       write(*,*) "rrfac min/max:", MINVAL(rrfac), MAXVAL(rrfac)
+       write(*,*) "landfrac min/max:", MINVAL(landfrac), MAXVAL(landfrac)
+       write(*,*) "nu_lap_unit_sphere:", nu_lap_unit_sphere
+       write(*,*) "dt:", dt
+       write(*,*) "stretch_factor:", stretch_factor         
          if (.not. do_schmidt) then
             !––– ORIGINAL UNIFORM SMOOTHER ––––––––––––––––––––––––––––
             write(*,*) "Smooth height (uniform)"
@@ -343,7 +342,7 @@ CONTAINS
                call progress_bar("# ", iter, 100.0_r8*iter/smooth_phis_numcycle)
                call laplacian(terr_sm, ncube, lap, landfrac_local, lsmoothing_over_ocean)
                terr_sm = terr_sm + lap*dt*nu_lap_unit_sphere*rrfac_sm
-         
+
                if (MAXVAL(terr_sm) > 1.2_r8*max_terr .or. MINVAL(terr_sm) < min_terr-500._r8) then
                   write(*,*) "Laplace iteration seems to be unstable:"
                   write(*,*) "MIN, MAX(terr_sm) =", MINVAL(terr_sm), MAXVAL(terr_sm)
@@ -408,7 +407,11 @@ CONTAINS
       write(*,*) " Topo volume  AFTER smoother = ",volterr_sm/(6*sum(da))
       write(*,*) "            Difference       = ",(volterr_in - volterr_sm)/(6*sum(da))
 
+      write(*,*) "Before rescaling terr_sm min/max:", MINVAL(terr_sm), MAXVAL(terr_sm)
+      write(*,*) "volterr_in, volterr_sm:", volterr_in, volterr_sm
+
       terr_sm = (volterr_in/volterr_sm)*terr_sm
+      write(*,*) "After rescaling terr_sm min/max:", MINVAL(terr_sm), MAXVAL(terr_sm)
       volterr_sm=0.
       do ip=1,6 
          volterr_sm =  volterr_sm + sum( terr_sm(:,:,ip) * da )
@@ -423,6 +426,9 @@ CONTAINS
       
       ! Now do the subtraction
       terr_dev = terr_orig - terr_sm
+      write(*,*) "terr_orig min/max:", MINVAL(terr_orig), MAXVAL(terr_orig)
+      write(*,*) "terr_sm min/max (final):", MINVAL(terr_sm), MAXVAL(terr_sm)
+
 
       if (read_in_and_refine) then
         where( rr_updt <= 1. )

--- a/cube_to_target/smooth_topo_cube.F90
+++ b/cube_to_target/smooth_topo_cube.F90
@@ -85,12 +85,13 @@ CONTAINS
 
     logical             :: do_schmidt                             ! needed for stretched grid - do_schmidt
     real(r8)            :: target_lon, target_lat, stretch_factor ! needed for stretched grid - do_schmidt
-    real(r8)            :: base_dt, alpha                         ! needed for stretched grid - do_schmidt
+    real(r8)            :: base_dt                                ! needed for stretched grid - do_schmidt
+    real(r8)            :: alpha = 1.0_r8         ! Default alpha ! needed for stretched grid - do_schmidt
 
-    real(r8), parameter :: rearth = 6.37122e6 !radius of Earth from CIME/CESM
+    real(r8), parameter :: rearth = 6.37122e6                     !radius of Earth from CIME/CESM
     real(r8)            :: nu_lap_unit_sphere,dt
-    real(r8)            :: min_terr, max_terr   !to check if Laplacian smoother is stable
-    real(r8)            :: min_rrfac, max_rrfac !to check if Laplacian smoother is stable
+    real(r8)            :: min_terr, max_terr                     !to check if Laplacian smoother is stable
+    real(r8)            :: min_rrfac, max_rrfac                   !to check if Laplacian smoother is stable
 
     ! If caller forgot to set the flag, infer it from rrfac & refinement
     if (.not. lsmooth_rrfac) then   
@@ -112,7 +113,7 @@ CONTAINS
        write(*,*) " Read precomputed filtered topography from ",trim(smooth_topo_fname)
        call read_topo_smooth_data(smooth_topo_fname,ncube*ncube*6,terr_sm,terr_dev)
     
-       if (.NOT. lregional_refinement) RETURN  ! explicitly preserve original early-return logic
+       if (.NOT. lregional_refinement) RETURN  
     
        ! Proceed only if refinement is requested
        terr_sm00  = terr_sm
@@ -268,7 +269,7 @@ CONTAINS
          end if
 
          ! Stretch-grid control (YAML may say DO_SCHMIDT: true/false)
-         call read_gen_scrip('GenScrip.yaml', do_schmidt, target_lon, target_lat, stretch_factor)
+         call read_gen_scrip('GenScrip.yaml', do_schmidt, target_lon, target_lat, stretch_factor, alpha)
 
        !---------------------------------------------------------------------------------------
        !  Surface-height smoothing
@@ -293,19 +294,9 @@ CONTAINS
        !            base_dt = 16 / smooth_phis_numcycle         (regular-grid value)
        !            dt      = base_dt / (stretch_factor*4)      (extra safety for zoom)
        !
-       !        `stretch_factor` is the Schmidt refinement factor n.
-       !            Local grid spacing = coarse-grid spacing / n
-       !            Effective resolution = C_base × n
-       !               examples:  (C-equivalent values are illustrative; any n≥1 works.)
-       !                   C270  with n = 2.5   → local ≈ C675
-       !                   C540  with n = 2.5   → local ≈ C1350
-       !                   C1539 with n = 3.0   → local ≈ C4617
        !        The extra “×4” in  dt = base_dt / (n*4)  is a universal safety
        !        margin so the smallest refined cell stays within the global CFL
        !        limit, independent of the exact value of n.
-       !
-       !      – Limit each update with an empirical α = 0.3 to damp the first
-       !        iteration spike that can appear at sharp terrain steps.
        !
        !   The guard:
        !        if (.not. any(rrfac > 0.)) then
@@ -313,15 +304,6 @@ CONTAINS
        !        endif
        !    allows the exact same subroutine to run on a regular grid where
        !    rr_factor==1 everywhere (the new maths collapses to the old one).
-       !
-       !   Runtime sanity-check:
-       !        MAXVAL(terr_sm) > 1.2*MAX(terr)  OR  MINVAL(terr_sm) < MIN(terr)-500 m
-       !    catches a divergence early and aborts with a clear message instead
-       !    of corrupting the topo file.
-       !
-       ! Short version: all extra factors keep ∆t/∆x² locally the same as the
-       ! coarse grid, so stretched runs are stable while regular runs remain
-       ! bit-for-bit identical to the historical smoother.
        !========================================================================================
        write(*,*) "Before smoothing checks:"
        write(*,*) "terr min/max:", MINVAL(terr), MAXVAL(terr)
@@ -372,11 +354,11 @@ CONTAINS
                max_terr = MAXVAL(terr);  min_terr = MINVAL(terr)
                base_dt  = 16.0_r8 / REAL(smooth_phis_numcycle, r8)
                dt       = base_dt / (stretch_factor*4.0_r8)   ! tighter CFL for stretched
-               alpha    = 0.3_r8                              ! optional limiter
          
                do iter = 1, smooth_phis_numcycle
                   call progress_bar("# ", iter, 100.0_r8*iter/smooth_phis_numcycle)
                   call laplacian(terr_sm, ncube, lap, landfrac, lsmoothing_over_ocean)
+                  ! alpha change in terr_sm  will tune gwd (which is SGH)
                   terr_sm = terr_sm + alpha*(lap*dt*nu_lap_unit_sphere*rrfac_sm)
          
                   if (MAXVAL(terr_sm) > 1.2_r8*max_terr .or. MINVAL(terr_sm) < min_terr-500._r8) then
@@ -387,12 +369,12 @@ CONTAINS
             end if
          end if ! <– closes “if (.not. do_schmidt)”
        endif    ! <- closes "IF (ldistance_weighted_smoother)"
-!====================================================================
-! >>> be sure refined cap is merged with coarse halo <<<
-!====================================================================
-         ! Any cell whose r‑factor update is > 1 belongs to the refined cap.
-         ! Copy refined topo over the pre‑existing coarse field.
-         ! build mask once, independent of smoother branch
+    !====================================================================
+    ! >>> be sure refined cap is merged with coarse halo <<<
+    !====================================================================
+     ! Any cell whose r‑factor update is > 1 belongs to the refined cap.
+     ! Copy refined topo over the pre‑existing coarse field.
+     ! build mask once, independent of smoother branch
       if (lregional_refinement) rr_updt = rrfac 
 
       if (lregional_refinement) then
@@ -466,20 +448,21 @@ CONTAINS
 
  !-------------------------------------------------------------------
  ! read_gen_scrip
- !   Reads four key/value lines from GenScrip.yaml:
- !     DO_SCHMIDT, TARGET_LON, TARGET_LAT, STRETCH_FACTOR
+ !   Reads five key/value lines from GenScrip.yaml:
+ !     DO_SCHMIDT, TARGET_LON, TARGET_LAT, STRETCH_FACTOR, ALPHA
  !   Returns them through the intent-out arguments.
  !   If the file can’t be opened the routine simply returns with
  !   default values (no Schmidt stretching).
  !-------------------------------------------------------------------
 
-  subroutine read_gen_scrip(  cfgFile   , do_schmidt  , target_lon , target_lat    , stretch_factor )
+  subroutine read_gen_scrip(  cfgFile   , do_schmidt  , target_lon , target_lat    , stretch_factor , alpha)  
     implicit none
   
     !-- arguments
     character(len=*), intent(in ) :: cfgFile
     logical        , intent(out) :: do_schmidt
     real(r8)       , intent(out) :: target_lon, target_lat, stretch_factor
+    real(r8)       , intent(out) :: alpha
   
     !-- locals
     integer              :: ios, unit, idx
@@ -491,6 +474,7 @@ CONTAINS
     target_lon     =  0.0_r8 
     target_lat     =  0.0_r8
     stretch_factor =  1.0_r8
+    alpha          =  1.0_r8
             
     open(newunit=unit, file=cfgFile, status='old', action='read', iostat=ios)
     if (ios /= 0) then 
@@ -519,6 +503,15 @@ CONTAINS
         read(valstr, *) target_lat
       case('STRETCH_FACTOR')
         read(valstr, *) stretch_factor 
+      case('ALPHA')
+        if (len_trim(valstr) > 0) then
+          read(valstr, *, iostat=ios) alpha
+          if (ios /= 0) then
+            write(*,*) 'WARNING: Could not parse ALPHA="', trim(valstr), '" – keeping default alpha=', alpha
+          end if
+        else
+          ! leave the default alpha as-is (e.g., 1.0 if we don't need to tune GWD)
+        end if
       end select
     end do   
          


### PR DESCRIPTION
**Summary of code changes:**
`smooth_topo_cube.F90: `
Added Schmidt-aware Laplacian smoothing with fallback to uniform grid when refinement (rrfac) equals 1. 
`cube_to_target.F90:` 
Implemented dynamic array resizing (ensure_capacity) for overlap weights, introduced default refinement factor (rrfac=1.0).
`ridge_ana.F90:` 
Scaled overlap weights by local refinement (wgt *= rr_factor) ensuring correct ridge/GWD areas.
Fixed indexing bug.  ( by @aoloso )
`remap.F90:`
Introduced extensive guard conditions and checks to handle negative or near-zero overlap weights. Ensures stability during field remapping onto stretched grids.
`neighbor_search_mod.F90:`
Added new module to efficiently search nearest valid neighbors for fallback terrain filling. Updated with k-tree logic search. (by @aoloso) 
`shared_vars.F90:`
`Makefile & CMakeLists.txt`
Modified build configurations to include new module (neighbor_search_mod.F90) and ensure correct dependencies between modules.

Extensive in code comments were added for clarity and documentation purposes, explaining the rationale behind key implementation choices. These comments can be streamlined or removed if deemed excessively detailed.

**These separate two codes are under [GEOSgcm_GrdiComp:](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/1054)**
`generate_scrip_cube.F90: `
Enabled corner reordering for positive area SCRIP polygons on stretched grids.
`make_topo.py: `
Added logic to handle correct --rrfac_max for stretched grids.

**NOTEs:** 
1. Changes are invasive by necessity, as this was the only feasible approach to incorporate stretched grids within the existing framework.
2. The current maximum stable stretch factor tested and verified is 3.0 (used for c1539 grid configuration). Increasing the stretch beyond 3.0 significantly increases cell distortion and can introduce numerical instabilities, particularly due to very small target cell areas. Such extreme distortions are currently unsupported and should be avoided.  While the center of stretch grid can be freely adjusted (lon/lat coordinates), reducing the stretch factor below 3.0 is safe as well and fully supported. 


