### PR TITLE
Fix for GNU Namelist error

### DIFF
--- a/bin_to_cube/bin_to_cube.F90
+++ b/bin_to_cube/bin_to_cube.F90
@@ -8,7 +8,7 @@
 !                The LANDM_COSLAT field is read in from a separate netCDF file and linearly
 !                interpolated to the 3km cubed-sphere grid.
 !
-!  Author: Peter Hjort Lauritzen (pel@ucar.edu) 
+!  Author: Peter Hjort Lauritzen (pel@ucar.edu)
 !
 !  ROUTINES CALLED:
 !       netcdf routines
@@ -21,17 +21,17 @@ program convterr
 #     include         <netcdf.inc>
   !
   integer :: im, jm
-  
+
 !  integer,  parameter :: ncube = 3000 !dimension of cubed-sphere grid
   integer :: ncube !dimension of cubed-sphere grid
 !  integer,  parameter :: ncube = 540 !dimension of cubed-sphere grid - for debugging
-  
+
   integer*2,  allocatable, dimension(:,:) :: terr               ! global 30-sec terrain data
 !+++ARH
   integer*1,  allocatable, dimension(:,:) :: landfrac ! global 30-sec land fraction
 !---ARH
-  
-  integer :: alloc_error,dealloc_error  
+
+  integer :: alloc_error,dealloc_error
   integer :: i,j,n,k,index                                ! index
   integer*2, allocatable, dimension(:,:)  :: iterr        ! terrain data for 30-sec tile
 !+++ARH
@@ -39,20 +39,20 @@ program convterr
   integer ncid,status, dimlatid,dimlonid, landid, topoid  ! for netCDF USGS data file
 !---ARH
   integer :: srcid,dstid                                  ! for netCDF weight file
-  
+
   real(r8), allocatable, dimension(:)   :: lon  , lat
   real(r8), allocatable, dimension(:)   :: lon_landm  , lat_landm
   real(r8), allocatable, dimension(:,:) :: landm_coslat
   integer :: im_landm, jm_landm
   integer :: lonid, latid
   integer :: lon_vid, lat_vid
-  
+
   REAL    (r8), PARAMETER :: tiny  = 1.0E-10
   REAL    (r8), PARAMETER :: pi    = 3.14159265358979323846264338327
   REAL    (r8), PARAMETER :: piq   = 0.25*pi
   REAL    (r8), PARAMETER :: rad2deg   = 180.0/pi
   REAL    (r8), PARAMETER :: deg2rad   = pi/180.0
-  
+
   real(r8) :: alpha, beta,da,wt,dlat
   integer  :: ipanel,icube,jcube
 !+++ARH
@@ -87,11 +87,12 @@ program convterr
   character(len=1024) :: raw_latlon_data_file,output_file
   integer(kind=8) :: tclock1_g, tclock2_g, clock_rate_g
   real(kind=8) :: elapsed_time_g
-  call system_clock(tclock1_g)
-  
+
   namelist /binparams/ &
        raw_latlon_data_file,output_file,ncube
-  
+
+  call system_clock(tclock1_g)
+
   UNIT=221
   OPEN( UNIT=UNIT, FILE="bin_to_cube.nl" ) !, NML =  cntrls )
   READ( UNIT=UNIT, NML=binparams)
@@ -104,19 +105,19 @@ program convterr
   status = nf_open(raw_latlon_data_file, 0, ncid)
   write(*,*) "Opening: ",TRIM(raw_latlon_data_file)
   IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR(STATUS)
-  
+
   status = NF_INQ_DIMID(ncid, 'lat', dimlatid)
   IF (status .NE. NF_NOERR) CALL HANDLE_ERR(status)
   status = NF_INQ_DIMLEN(ncid, dimlatid, jm)
   IF (status .NE. NF_NOERR) CALL HANDLE_ERR(status)
-  
+
   status = NF_INQ_DIMID(ncid, 'lon', dimlonid)
   IF (status .NE. NF_NOERR) CALL HANDLE_ERR(status)
   status = NF_INQ_DIMLEN(ncid, dimlonid, im)
   IF (status .NE. NF_NOERR) CALL HANDLE_ERR(status)
-  
+
   WRITE(*,*) "lon-lat dimensions: ",im,jm
-  
+
 !+++ARH
   allocate ( landfrac(im,jm),stat=alloc_error )
   if( alloc_error /= 0 ) then
@@ -124,40 +125,40 @@ program convterr
     stop
   end if
 !---ARH
-  
+
   allocate ( terr(im,jm),stat=alloc_error )
   if( alloc_error /= 0 ) then
     print*,'Program could not allocate space for terr'
     stop
   end if
-  
+
   allocate ( lon(im),stat=alloc_error )
   if( alloc_error /= 0 ) then
     print*,'Program could not allocate space for lon'
     stop
   end if
-  
+
   allocate ( lat(jm),stat=alloc_error )
   if( alloc_error /= 0 ) then
     print*,'Program could not allocate space for lat'
     stop
   end if
-  
+
   terr = -9999
 !+++ARH
   landfrac = -99.0
 
   status = NF_INQ_VARID(ncid, 'landfract', landid)
   IF (status .NE. NF_NOERR) CALL HANDLE_ERR(status)
-  
+
   status = NF_GET_VAR_INT1(ncid, landid,landfrac)
   IF (status .NE. NF_NOERR) CALL HANDLE_ERR(status)
   WRITE(*,*) "min/max of 30sec land fraction",MINVAL(landfrac),MAXVAL(landfrac)
-!---ARH  
-  
+!---ARH
+
   status = NF_INQ_VARID(ncid, 'htopo', topoid)
   IF (status .NE. NF_NOERR) CALL HANDLE_ERR(status)
-  
+
   read_terrain_data: block
   integer(kind=8) :: tclock1, tclock2, clock_rate
   real(kind=8) :: elapsed_time
@@ -169,17 +170,17 @@ program convterr
   elapsed_time = real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8)
   print *, 'Elapsed time read terrain data in bin_to_cube = ', elapsed_time, ' seconds.'
   end block read_terrain_data
-  
+
   status = NF_INQ_VARID(ncid, 'lon', lonid)
   IF (status .NE. NF_NOERR) CALL HANDLE_ERR(status)
-  
+
   WRITE(*,*) "read lon"
   status = NF_GET_VAR_DOUBLE(ncid, lonid,lon)
   IF (status .NE. NF_NOERR) CALL HANDLE_ERR(status)
-  
+
   status = NF_INQ_VARID(ncid, 'lat', latid)
   IF (status .NE. NF_NOERR) CALL HANDLE_ERR(status)
-  
+
   WRITE(*,*) "read lat"
   status = NF_GET_VAR_DOUBLE(ncid, latid,lat)
   IF (status .NE. NF_NOERR) CALL HANDLE_ERR(status)
@@ -187,10 +188,10 @@ program convterr
   print *,"close file"
   status = nf_close (ncid)
   if (status .ne. NF_NOERR) call handle_err(status)
-  
+
   WRITE(*,*) 'done reading data from netCDF file'
-  
-  
+
+
   WRITE(*,*) "compute volume for raw data"
   vol = 0.0
   dx = (lon(2)-lon(1))
@@ -216,70 +217,70 @@ program convterr
   WRITE(*,*) "read LANDM_COSLAT from file"
   status = nf_open('landm_coslat.nc', 0, ncid)
   IF (STATUS .NE. NF_NOERR) CALL HANDLE_ERR(STATUS)
-  
+
   status = NF_INQ_DIMID(ncid, 'lat', dimlatid)
   IF (status .NE. NF_NOERR) CALL HANDLE_ERR(status)
   status = NF_INQ_DIMLEN(ncid, dimlatid, jm_landm)
   IF (status .NE. NF_NOERR) CALL HANDLE_ERR(status)
-  
+
   status = NF_INQ_DIMID(ncid, 'lon', dimlonid)
   IF (status .NE. NF_NOERR) CALL HANDLE_ERR(status)
   status = NF_INQ_DIMLEN(ncid, dimlonid, im_landm)
   IF (status .NE. NF_NOERR) CALL HANDLE_ERR(status)
-  
+
   WRITE(*,*) "lon-lat dimensions: ",im_landm,jm_landm
-  
+
   allocate ( landm_coslat(im_landm,jm_landm),stat=alloc_error )
   if( alloc_error /= 0 ) then
     print*,'Program could not allocate space for smoothed landfrac'
     stop
   end if
-  
+
   allocate ( lon_landm(im_landm),stat=alloc_error )
   if( alloc_error /= 0 ) then
     print*,'Program could not allocate space for smoothed landfrac'
     stop
   end if
-  
+
   allocate ( lat_landm(jm_landm),stat=alloc_error )
   if( alloc_error /= 0 ) then
     print*,'Program could not allocate space for smoothed landfrac'
     stop
   end if
-  
+
   do j = 1, jm_landm
     do i = 1, im_landm
       landm_coslat(i,j) = -999999.99
     end do
   end do
-  
+
   status = NF_INQ_VARID(ncid, 'LANDM_COSLAT', landid)
   IF (status .NE. NF_NOERR) CALL HANDLE_ERR(status)
-  
+
   status = NF_GET_VAR_DOUBLE(ncid, landid,landm_coslat)
   IF (status .NE. NF_NOERR) CALL HANDLE_ERR(status)
   WRITE(*,*) "min/max of landm_coslat",MINVAL(landm_coslat),MAXVAL(landm_coslat)
-  
+
   status = NF_INQ_VARID(ncid, 'lon', lonid)
   IF (status .NE. NF_NOERR) CALL HANDLE_ERR(status)
-  
+
   WRITE(*,*) "read lon"
   status = NF_GET_VAR_DOUBLE(ncid, lonid,lon_landm)
   IF (status .NE. NF_NOERR) CALL HANDLE_ERR(status)
-  
+
   status = NF_INQ_VARID(ncid, 'lat', latid)
   IF (status .NE. NF_NOERR) CALL HANDLE_ERR(status)
-  
+
   WRITE(*,*) "read lat"
   status = NF_GET_VAR_DOUBLE(ncid, latid,lat_landm)
   IF (status .NE. NF_NOERR) CALL HANDLE_ERR(status)
-  
+
   print *,"close file"
   status = nf_close (ncid)
   if (status .ne. NF_NOERR) call handle_err(status)
-  
+
   WRITE(*,*) 'done reading in LANDM_COSLAT data from netCDF file'
-  
+
   !
   ! bin data on cubed-sphere grid
   !
@@ -313,8 +314,8 @@ program convterr
     stop
   end if
   landm_coslat_cube = 0.0
-  
-  
+
+
   allocate ( idx(im,jm),stat=alloc_error )
   if( alloc_error /= 0 ) then
     print*,'Program could not allocate space for idx'
@@ -330,7 +331,7 @@ program convterr
     print*,'Program could not allocate space for idp'
     stop
   end if
-  
+
   WRITE(*,*) "bin lat-lon data to cubed-sphere"
 
   !
@@ -352,7 +353,7 @@ program convterr
     wt    = SIN( lat(j)+0.5*dlat ) - SIN( lat(j)-0.5*dlat )
     DO i=1,im
 !      WRITE(*,ADVANCE = "NO") "bin to cube ",100.0*FLOAT(i+(j-1)*im)/FLOAT(im*jm),"% done"
-      call CubedSphereABPFromRLL(lon(i), lat(j), alpha, beta, ipanel)            
+      call CubedSphereABPFromRLL(lon(i), lat(j), alpha, beta, ipanel)
       icube = CEILING((alpha + piq) / da)
       jcube = CEILING((beta  + piq) / da)
       IF (icube<1.OR.icube>ncube.OR.jcube<1.OR.jcube>ncube) THEN
@@ -378,7 +379,7 @@ program convterr
   elapsed_time = real(tclock2 - tclock1, kind=8) / real(clock_rate, kind=8)
   print *, 'Elapsed time block1 in bin_to_cube = ', elapsed_time, ' seconds.'
   end block block1
-  
+
 
   dx = deg2rad*(lon_landm(2)-lon_landm(1))
   !
@@ -386,7 +387,7 @@ program convterr
   !
   dy = deg2rad*(lat_landm(2)-lat_landm(1))
   DO k=1,6
-    DO j=1,ncube          
+    DO j=1,ncube
       DO i=1,ncube
         IF (ABS(weight(i,j,k))<1.0E-9) THEN
           WRITE(*,*) "there is no lat-lon grid point in cubed sphere cell ",i,j,k
@@ -394,9 +395,9 @@ program convterr
           write(*,*) "weight     ",i,j,k,weight(i,j,k)
           STOP
         ELSE
-          terr_cube        (i,j,k) = terr_cube        (i,j,k)/weight(i,j,k)                
+          terr_cube        (i,j,k) = terr_cube        (i,j,k)/weight(i,j,k)
 !+++ARH
-          landfrac_cube    (i,j,k) = landfrac_cube    (i,j,k)/weight(i,j,k)                
+          landfrac_cube    (i,j,k) = landfrac_cube    (i,j,k)/weight(i,j,k)
 !---ARH
         END IF
         !
@@ -404,7 +405,7 @@ program convterr
         !
         alpha = -piq+(i-0.5)*da
         beta  = -piq+(j-0.5)*da
-        CALL CubedSphereRLLFromABP(alpha, beta, k, lambda, theta)   
+        CALL CubedSphereRLLFromABP(alpha, beta, k, lambda, theta)
         IF (theta>lat_landm(jm_landm)*deg2rad-tiny) THEN
           landm_coslat_cube(i,j,k) = 0.0
         ELSE IF (theta<lat_landm(1)*deg2rad+tiny) THEN
@@ -422,7 +423,7 @@ program convterr
           wy = (theta -lat_landm(ilat)*deg2rad)/(lat_landm(jp1)-lat_landm(ilat))
           !
           ! since LANDM_COSLAT is not equally spaced in latitude a search is needed
-          ! 
+          !
           DO WHILE (wy>1.0.OR.wy<0.0)
             jp1  = ilat+1
             wy = (theta -lat_landm(ilat)*deg2rad)/((lat_landm(jp1)-lat_landm(ilat))*deg2rad)
@@ -432,7 +433,7 @@ program convterr
               ilat=ilat-1
             END IF
           END DO
-          
+
           IF (wx>1.0+tiny.OR.wx<0.0-tiny) THEN
             WRITE(*,*) "wx out of range",wx
             stop
@@ -470,7 +471,7 @@ program convterr
         vol_cube = vol_cube+terr_cube(i,j,ipanel)*darea_cube(i,j)
       end do
     end do
-  end do 
+  end do
   vol_cube=vol_cube/(4.0*pi)
   deallocate(darea_cube)
   WRITE(*,*) "mean height (globally) of topography about sea-level (3km cube data)",vol_cube,(vol_cube-vol)/vol
@@ -514,7 +515,7 @@ program convterr
 !!                 write(*,*) "terr_cube_gmted2010(i,j,k)=",terr_cube_gmted2010(i,j,k)
 !!                 write(*,*) " "
 !                 terr_cube_gmted2010(i,j,k) = 1.0D0
-!              else 
+!              else
 !                 terr_cube_gmted2010(i,j,k) = 0.0D0
 !              end if
 !           END DO
@@ -548,18 +549,18 @@ end program convterr
 !--------------------------------------------------------------------------
 
 subroutine handle_err(status)
-  
+
   implicit         none
-  
+
 #     include          <netcdf.inc>
-  
+
   integer          status
-  
+
   if (status .ne. nf_noerr) then
     print *, nf_strerror(status)
     stop 'Stopped'
   endif
-  
+
 end subroutine handle_err
 
 
@@ -580,84 +581,84 @@ end subroutine handle_err
 SUBROUTINE CubedSphereABPFromRLL(lon, lat, alpha, beta, ipanel)
   use shr_kind_mod, only: r8 => shr_kind_r8
   IMPLICIT NONE
-  
+
   REAL    (R8), INTENT(IN)  :: lon, lat
   REAL    (R8), INTENT(OUT) :: alpha, beta
   INTEGER, INTENT(OUT) :: ipanel
   REAL    (r8), PARAMETER :: pi   = 3.14159265358979323846264338327
   REAL    (r8), PARAMETER :: piq   = 0.25*pi
   REAL    (r8), PARAMETER :: rotate_cube = 0.0
-  
+
   ! Local variables
   REAL    (R8) :: xx, yy, zz, pm
   REAL    (R8) :: sx, sy, sz
   INTEGER  :: ix, iy, iz
-  
+
   ! Translate to (x,y,z) space
   xx = COS(lon-rotate_cube) * COS(lat)
   yy = SIN(lon-rotate_cube) * COS(lat)
   zz = SIN(lat)
-  
+
   pm = MAX(ABS(xx), ABS(yy), ABS(zz))
-  
+
   ! Check maximality of the x coordinate
   IF (pm == ABS(xx)) THEN
     IF (xx > 0) THEN; ix = 1; ELSE; ix = -1; ENDIF
   ELSE
     ix = 0
   ENDIF
-  
+
   ! Check maximality of the y coordinate
   IF (pm == ABS(yy)) THEN
     IF (yy > 0) THEN; iy = 1; ELSE; iy = -1; ENDIF
   ELSE
     iy = 0
   ENDIF
-      
+
   ! Check maximality of the z coordinate
   IF (pm == ABS(zz)) THEN
     IF (zz > 0) THEN; iz = 1; ELSE; iz = -1; ENDIF
   ELSE
     iz = 0
   ENDIF
-  
+
   ! Panel assignments
   IF (iz  ==  1) THEN
     ipanel = 6; sx = yy; sy = -xx; sz = zz
-    
+
   ELSEIF (iz  == -1) THEN
     ipanel = 5; sx = yy; sy = xx; sz = -zz
-    
+
   ELSEIF ((ix == 1) .AND. (iy /= 1)) THEN
     ipanel = 1; sx = yy; sy = zz; sz = xx
-    
+
   ELSEIF ((ix == -1) .AND. (iy /= -1)) THEN
     ipanel = 3; sx = -yy; sy = zz; sz = -xx
-    
+
   ELSEIF ((iy == 1) .AND. (ix /= -1)) THEN
     ipanel = 2; sx = -xx; sy = zz; sz = yy
-    
+
   ELSEIF ((iy == -1) .AND. (ix /=  1)) THEN
     ipanel = 4; sx = xx; sy = zz; sz = -yy
-    
+
   ELSE
     WRITE(*,*) 'Fatal Error: CubedSphereABPFromRLL failed'
     WRITE(*,*) '(xx, yy, zz) = (', xx, ',', yy, ',', zz, ')'
     WRITE(*,*) 'pm =', pm, ' (ix, iy, iz) = (', ix, ',', iy, ',', iz, ')'
     STOP
   ENDIF
-  
+
   ! Use panel information to calculate (alpha, beta) coords
   alpha = ATAN(sx / sz)
   beta = ATAN(sy / sz)
-  
+
 END SUBROUTINE CubedSphereABPFromRLL
 
 
 
 !
 ! write netCDF file
-! 
+!
 !+++ARH
 subroutine wrt_cube(ncube,terr_cube,landfrac_cube,landm_coslat_cube,var30_cube,raw_latlon_data_file,output_file)
 !subroutine wrt_cube(ncube,terr_cube,landm_coslat_cube,var30_cube,raw_latlon_data_file,output_file)
@@ -665,7 +666,7 @@ subroutine wrt_cube(ncube,terr_cube,landfrac_cube,landm_coslat_cube,var30_cube,r
   use shr_kind_mod, only: r8 => shr_kind_r8
   implicit none
 #     include         <netcdf.inc>
-  
+
   !
   ! Dummy arguments
   !
@@ -683,10 +684,10 @@ subroutine wrt_cube(ncube,terr_cube,landfrac_cube,landm_coslat_cube,var30_cube,r
   !     grid coordinates and masks
   !
   !-----------------------------------------------------------------------
-  
+
   real (r8), dimension(6*ncube*ncube) :: grid_center_lat  ! lat/lon coordinates for
   real (r8), dimension(6*ncube*ncube) :: grid_center_lon  ! each grid center in degrees
-  
+
   integer  :: ncstat             ! general netCDF status variable
   integer  :: nc_grid_id         ! netCDF grid dataset id
   integer  :: nc_gridsize_id     ! netCDF grid size dim id
@@ -701,13 +702,13 @@ subroutine wrt_cube(ncube,terr_cube,landfrac_cube,landm_coslat_cube,var30_cube,r
 !---ARH
   integer  :: nc_landm_coslat_id
   integer  :: nc_var_id
-  
-  
+
+
   integer, dimension(2) :: nc_dims2_id ! netCDF dim id array for 2-d arrays
   integer :: grid_dims
-  
+
   character(90), parameter :: grid_name = 'equi-angular gnomonic cubed sphere grid'
-  
+
   character (len=32) :: fout       ! NetCDF output file
   integer            :: foutid     ! Output file id
   integer            :: lonid, lonvid
@@ -715,26 +716,26 @@ subroutine wrt_cube(ncube,terr_cube,landfrac_cube,landm_coslat_cube,var30_cube,r
   integer            :: status    ! return value for error control of netcdf routin
   integer            :: i,j,k
   character (len=8)  :: datestring
-  
+
   integer  :: atm_add,n
   real(r8) :: xgno_ce,lon,ygno_ce,lat
-  
+
   REAL    (r8), PARAMETER :: pi    = 3.14159265358979323846264338327
   REAL    (r8), PARAMETER :: piq   = 0.25*pi
   REAL    (r8), PARAMETER :: rad2deg   = 180.0/pi
-  
+
   real(r8) :: da, a1,a2,a3,a4,dbg_area,max_size
   real(r8), dimension(2,2) :: ang
   real(r8) :: tmp_lon,min_lon,max_lon!,sum,lflag_value
   logical :: lflag
 !  character(100), parameter :: grid_file_out = 'gmted2010-modis-ncube3000.nc'
 
-  
+
   grid_dims = 6*ncube*ncube
-  
+
   dbg_area = 0.0
-  
-  da = pi / DBLE(2*ncube)        
+
+  da = pi / DBLE(2*ncube)
   atm_add = 1
   do k=1,6
     do j=1,ncube
@@ -742,30 +743,30 @@ subroutine wrt_cube(ncube,terr_cube,landfrac_cube,landm_coslat_cube,var30_cube,r
       do i=1,ncube
         xgno_ce = -piq + da * (DBLE(i-1)+0.5)
         call CubedSphereRLLFromABP(xgno_ce, ygno_ce, k, lon, lat)
-        grid_center_lon(atm_add  ) = lon*rad2deg                          
-        grid_center_lat(atm_add  ) = lat*rad2deg                                    
+        grid_center_lon(atm_add  ) = lon*rad2deg
+        grid_center_lat(atm_add  ) = lat*rad2deg
         atm_add = atm_add+1
       end do
     end do
   end do
-  
+
   WRITE(*,*) "Create NetCDF file for output: ", TRIM(output_file)
   ncstat = nf_create (TRIM(output_file), NF_64BIT_DATA,nc_grid_id)
   call handle_err(ncstat)
-  
+
   ncstat = nf_put_att_text (nc_grid_id, NF_GLOBAL, 'title',len_trim(grid_name), grid_name)
   call handle_err(ncstat)
 
-  ncstat = nf_put_att_text (nc_grid_id, NF_GLOBAL, 'raw_topo',len_trim(raw_latlon_data_file), TRIM(raw_latlon_data_file)) 
+  ncstat = nf_put_att_text (nc_grid_id, NF_GLOBAL, 'raw_topo',len_trim(raw_latlon_data_file), TRIM(raw_latlon_data_file))
   call handle_err(ncstat)
 
   git_http='https://github.com/NCAR/Topo.git'
-  
-  ncstat = nf_put_att_text (nc_grid_id, NF_GLOBAL, 'source_code',len_trim(git_http), TRIM(git_http)) 
+
+  ncstat = nf_put_att_text (nc_grid_id, NF_GLOBAL, 'source_code',len_trim(git_http), TRIM(git_http))
   call handle_err(ncstat)
 
-  tmp_string='LANDM_COSLAT is only used in CAM4'  
-  ncstat = nf_put_att_text (nc_grid_id, NF_GLOBAL, 'note',len_trim(tmp_string), TRIM(tmp_string)) 
+  tmp_string='LANDM_COSLAT is only used in CAM4'
+  ncstat = nf_put_att_text (nc_grid_id, NF_GLOBAL, 'note',len_trim(tmp_string), TRIM(tmp_string))
   call handle_err(ncstat)
 
   call DATE_AND_TIME(DATE=datestring)
@@ -774,52 +775,52 @@ subroutine wrt_cube(ncube,terr_cube,landfrac_cube,landm_coslat_cube,var30_cube,r
   call handle_err(ncstat)
 
   tmp_string='Peter Hjort Lauritzen (NCAR)'
-  ncstat = nf_put_att_text (nc_grid_id, NF_GLOBAL, 'author',len_trim(tmp_string), TRIM(tmp_string)) 
+  ncstat = nf_put_att_text (nc_grid_id, NF_GLOBAL, 'author',len_trim(tmp_string), TRIM(tmp_string))
   call handle_err(ncstat)
 
   WRITE(*,*) "define grid size dimension"
   ncstat = nf_def_dim (nc_grid_id, 'grid_size', 6*ncube*ncube, nc_gridsize_id)
   call handle_err(ncstat)
-  
+
   WRITE(*,*) "define grid rank dimension"
   ncstat = nf_def_dim (nc_grid_id, 'grid_rank', 1, nc_gridrank_id)
   call handle_err(ncstat)
-  
+
   WRITE(*,*) "define grid dimension size array"
   ncstat = nf_def_var (nc_grid_id, 'grid_dims', NF_INT,1, nc_gridrank_id, nc_griddims_id)
   call handle_err(ncstat)
-  
+
   WRITE(*,*) "define grid center latitude array"
   ncstat = nf_def_var (nc_grid_id, 'lat', NF_DOUBLE,1, nc_gridsize_id, nc_grdcntrlat_id)
-  call handle_err(ncstat)        
+  call handle_err(ncstat)
   ncstat = nf_put_att_text (nc_grid_id, nc_grdcntrlat_id, 'units',13, 'degrees_north')
   call handle_err(ncstat)
-  
+
   WRITE(*,*) "define grid center longitude array"
   ncstat = nf_def_var (nc_grid_id, 'lon', NF_DOUBLE,1, nc_gridsize_id, nc_grdcntrlon_id)
   call handle_err(ncstat)
   ncstat = nf_put_att_text (nc_grid_id, nc_grdcntrlon_id, 'units',12, 'degrees_east')
   call handle_err(ncstat)
-  
+
   WRITE(*,*) "define terr_cube array"
   ncstat = nf_def_var (nc_grid_id, 'terr', NF_DOUBLE,1, nc_gridsize_id, nc_terr_id)
   call handle_err(ncstat)
   ncstat = nf_put_att_text (nc_grid_id, nc_terr_id, 'units',1, 'm')
   call handle_err(ncstat)
-!+++ARH 
+!+++ARH
   WRITE(*,*) "define landfrac_cube array"
   ncstat = nf_def_var (nc_grid_id, 'LANDFRAC', NF_DOUBLE,1, nc_gridsize_id, nc_landfrac_id)
   call handle_err(ncstat)
   ncstat = nf_put_att_text (nc_grid_id, nc_landfrac_id, 'long_name',70,&
        'land ocean transition mask: ocean (0), continent (1), transition (0-1)')
   call handle_err(ncstat)
-!---ARH  
+!---ARH
   WRITE(*,*) "define landm_coslat_cube array"
   ncstat = nf_def_var (nc_grid_id, 'LANDM_COSLAT', NF_DOUBLE,1, nc_gridsize_id, nc_landm_coslat_id)
   call handle_err(ncstat)
   ncstat = nf_put_att_text (nc_grid_id, nc_landm_coslat_id, 'long_name',35,'smoothed land ocean transition mask')
   call handle_err(ncstat)
-  
+
   WRITE(*,*) "define var30_cube array"
   ncstat = nf_def_var (nc_grid_id, 'var30', NF_DOUBLE,1, nc_gridsize_id, nc_var_id)
   call handle_err(ncstat)
@@ -829,37 +830,37 @@ subroutine wrt_cube(ncube,terr_cube,landfrac_cube,landm_coslat_cube,var30_cube,r
   tmp_string ='variance of elevation from high res lat-lon to ~3km cubed-sphere'
   ncstat = nf_put_att_text (nc_grid_id, nc_var_id, 'long_name',len_trim(tmp_string),&
        trim(tmp_string))
-  
+
   WRITE(*,*) "end definition stage"
   ncstat = nf_enddef(nc_grid_id)
   call handle_err(ncstat)
-  
+
   !-----------------------------------------------------------------------
   !
   !     write grid data
   !
   !-----------------------------------------------------------------------
-  
-  
-  WRITE(*,*) "write grid data"        
+
+
+  WRITE(*,*) "write grid data"
   ncstat = nf_put_var_int(nc_grid_id, nc_griddims_id, grid_dims)
   call handle_err(ncstat)
-  
+
   ncstat = nf_put_var_double(nc_grid_id, nc_grdcntrlat_id, grid_center_lat)
   call handle_err(ncstat)
-  
+
   ncstat = nf_put_var_double(nc_grid_id, nc_grdcntrlon_id, grid_center_lon)
   call handle_err(ncstat)
-  
+
   ncstat = nf_put_var_double(nc_grid_id, nc_terr_id, terr_cube)
   call handle_err(ncstat)
-!+++ARH  
+!+++ARH
   ncstat = nf_put_var_double(nc_grid_id, nc_landfrac_id, landfrac_cube)
   call handle_err(ncstat)
-!---ARH  
+!---ARH
   ncstat = nf_put_var_double(nc_grid_id, nc_landm_coslat_id, landm_coslat_cube)
   call handle_err(ncstat)
-  
+
   ncstat = nf_put_var_double(nc_grid_id, nc_var_id, var30_cube)
   call handle_err(ncstat)
 
@@ -876,56 +877,56 @@ end subroutine wrt_cube
 !   Compute the area of all cubed sphere grid cells, storing the results in
 !   a two dimensional array.
 !
-! Parameters: 
+! Parameters:
 !   icube - Resolution of the cubed sphere
 !   dA (OUT) - Output array containing the area of all cubed sphere grid cells
 !------------------------------------------------------------------------------
 SUBROUTINE EquiangularAllAreas(icube, dA)
-  use shr_kind_mod, only: r8 => shr_kind_r8        
+  use shr_kind_mod, only: r8 => shr_kind_r8
   IMPLICIT NONE
-  
+
   INTEGER, INTENT(IN)                           :: icube
   REAL (r8), DIMENSION(icube,icube), INTENT(OUT) :: dA
-  
+
   ! Local variables
   INTEGER                       :: k, k1, k2
   REAL (r8)                          :: a1, a2, a3, a4
   REAL (r8), DIMENSION(icube+1,icube+1)  :: ang
   REAL (r8), DIMENSION(icube+1)      :: gp
-  
+
   REAL    (r8), PARAMETER :: pi   = 3.14159265358979323846264338327
   REAL    (r8), PARAMETER :: piq   = 0.25*pi
-  
-  
-  !#ifdef DBG 
+
+
+  !#ifdef DBG
   REAL (r8)   :: dbg1 !DBG
   !#endif
-  
+
   ! Recall that we are using equi-angular spherical gridding
   !   Compute the angle between equiangular cubed sphere projection grid lines.
   DO k = 1, icube+1
     gp(k) = -piq + (pi/DBLE(2*(icube))) * DBLE(k-1)
   ENDDO
-  
+
   DO k2=1,icube+1
     DO k1=1,icube+1
       ang(k1,k2) =ACOS(-SIN(gp(k1)) * SIN(gp(k2)))
     ENDDO
   ENDDO
-  
+
   DO k2=1,icube
     DO k1=1,icube
       a1 =      ang(k1  , k2  )
       a2 = pi - ang(k1+1, k2  )
       a3 = pi - ang(k1  , k2+1)
       a4 =      ang(k1+1, k2+1)
-      
+
       ! area = r*r*(-2*pi+sum(interior angles))
       DA(k1,k2) = -2.0*pi+a1+a2+a3+a4
     ENDDO
   ENDDO
-  
-  !#ifdef DBG 
+
+  !#ifdef DBG
   ! Only for debugging - test consistency
   dbg1 = 0.0                           !DBG
   DO k2=1,icube
@@ -953,25 +954,25 @@ END SUBROUTINE EquiangularAllAreas
 !   lat (OUT) - Calculated latitude
 !------------------------------------------------------------------------------
 SUBROUTINE CubedSphereRLLFromABP(alpha, beta, ipanel, lon, lat)
-  use shr_kind_mod, only: r8 => shr_kind_r8        
-  IMPLICIT NONE        
+  use shr_kind_mod, only: r8 => shr_kind_r8
+  IMPLICIT NONE
   REAL    (r8), INTENT(IN)  :: alpha, beta
   INTEGER     , INTENT(IN)  :: ipanel
-  REAL    (r8), INTENT(OUT) :: lon, lat        
+  REAL    (r8), INTENT(OUT) :: lon, lat
   ! Local variables
   REAL    (r8) :: xx, yy, zz, rotate_cube
   REAL    (r8), PARAMETER :: pi   = 3.14159265358979323846264338327
   REAL    (r8), PARAMETER :: piq  = 0.25*pi
-  
+
   rotate_cube = 0.0D0
   ! Convert to cartesian coordinates
-  CALL CubedSphereXYZFromABP(alpha, beta, ipanel, xx, yy, zz)        
+  CALL CubedSphereXYZFromABP(alpha, beta, ipanel, xx, yy, zz)
   ! Convert back to lat lon
   lat = ASIN(zz)
   if (xx==0.0.and.yy==0.0) THEN
     lon = 0.0
   else
-    lon = ATAN2(yy, xx) +rotate_cube 
+    lon = ATAN2(yy, xx) +rotate_cube
     IF (lon<0.0) lon=lon+2.0*pi
     IF (lon>2.0*pi) lon=lon-2.0*pi
   end if
@@ -993,36 +994,36 @@ END SUBROUTINE CubedSphereRLLFromABP
 !   zz (OUT) - Calculated z coordinate
 !------------------------------------------------------------------------------
 SUBROUTINE CubedSphereXYZFromABP(alpha, beta, ipanel, xx, yy, zz)
-  use shr_kind_mod, only: r8 => shr_kind_r8        
+  use shr_kind_mod, only: r8 => shr_kind_r8
   IMPLICIT NONE
-  
+
   REAL    (r8), INTENT(IN)  :: alpha, beta
   INTEGER     , INTENT(IN)  :: ipanel
-  REAL    (r8), INTENT(OUT) :: xx, yy, zz        
+  REAL    (r8), INTENT(OUT) :: xx, yy, zz
   ! Local variables
   REAL    (r8) :: a1, b1, pm
-  REAL    (r8) :: sx, sy, sz       
-  
+  REAL    (r8) :: sx, sy, sz
+
   ! Convert to Cartesian coordinates
   a1 = TAN(alpha)
   b1 = TAN(beta)
-  
+
   sz = (1.0 + a1 * a1 + b1 * b1)**(-0.5)
   sx = sz * a1
-  sy = sz * b1        
+  sy = sz * b1
   ! Panel assignments
   IF (ipanel == 6) THEN
-    yy = sx; xx = -sy; zz = sz          
+    yy = sx; xx = -sy; zz = sz
   ELSEIF (ipanel == 5) THEN
-    yy = sx; xx = sy; zz = -sz          
+    yy = sx; xx = sy; zz = -sz
   ELSEIF (ipanel == 1) THEN
-    yy = sx; zz = sy; xx = sz          
+    yy = sx; zz = sy; xx = sz
   ELSEIF (ipanel == 3) THEN
-    yy = -sx; zz = sy; xx = -sz          
+    yy = -sx; zz = sy; xx = -sz
   ELSEIF (ipanel == 2) THEN
-    xx = -sx; zz = sy; yy = sz          
+    xx = -sx; zz = sy; yy = sz
   ELSEIF (ipanel == 4) THEN
-    xx = sx; zz = sy; yy = -sz          
+    xx = sx; zz = sy; yy = -sz
   ELSE
     WRITE(*,*) 'Fatal Error: Panel out of range in CubedSphereXYZFromABP'
     WRITE(*,*) '(alpha, beta, panel) = (', alpha, ',', beta, ',', ipanel, ')'


### PR DESCRIPTION
A build of `bin_to_cube.F90` found a bug where a `namelist` was declared after an executable construct. This is invalid Fortran and GNU was not happy. So we re-order.